### PR TITLE
Poll git repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +128,7 @@ dependencies = [
  "async-trait",
  "automod",
  "base64",
+ "bincode",
  "bytesize",
  "clap",
  "colored",
@@ -154,6 +164,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "url",
+ "uuid",
  "yaque",
 ]
 
@@ -2185,6 +2196,15 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "thiserror",
  "time 0.3.20",
  "tokio",
+ "tokio-retry",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -1985,6 +1986,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "async-trait"
@@ -54,7 +54,7 @@ checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -91,7 +91,7 @@ checksum = "2820ec8709207251544277a96c4e97692107868a6c6096f2c8e0b32b66e942d6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -266,9 +266,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
+checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
 dependencies = [
  "os_str_bytes",
 ]
@@ -460,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
+checksum = "a9c00419335c41018365ddf7e4d5f1c12ee3659ddcf3e01974650ba1de73d038"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
+checksum = "fb8307ad413a98fff033c8545ecf133e3257747b3bae935e7602aab8aa92d4ca"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -482,24 +482,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 1.0.109",
+ "syn 2.0.4",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
+checksum = "edc52e2eb08915cb12596d29d55f0b5384f00d697a646dbd269b6ecb0fbd9d31"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
+checksum = "631569015d0d8d54e6c241733f944042623ab6df7bc3be7466874b05fcdb1c5f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -627,7 +627,7 @@ checksum = "5f00447f331c7f726db5b8532ebc9163519eed03c6d7c8b73c90b3ff5646ac85"
 dependencies = [
  "anyhow",
  "rustc_version",
- "spin 0.9.5",
+ "spin 0.9.6",
  "tracing-error",
 ]
 
@@ -677,7 +677,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project",
- "spin 0.9.5",
+ "spin 0.9.6",
 ]
 
 [[package]]
@@ -1016,16 +1016,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.53"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "0c17cc76786e99f8d2f055c11159e7f0091c42474dcc3189fbab96072e873e6d"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -1110,10 +1110,11 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
  "windows-sys 0.45.0",
 ]
@@ -1126,9 +1127,9 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
@@ -1147,9 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jobserver"
@@ -1197,9 +1198,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libm"
@@ -1266,9 +1267,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1406,9 +1407,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.46"
+version = "0.10.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd2523381e46256e40930512c7fd25562b9eae4812cb52078f155e87217c9d1e"
+checksum = "d8b277f87dacc05a6b709965d1cbafac4649d6ce9f3ce9ceb88508b5666dfec9"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -1438,9 +1439,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.81"
+version = "0.9.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176be2629957c157240f68f61f2d0053ad3a4ecfdd9ebf1e6521d18d9635cf67"
+checksum = "a95792af3c4e0153c3914df2261bedd30a98476f94dc892b67dfe1d89d433a04"
 dependencies = [
  "autocfg",
  "cc",
@@ -1451,9 +1452,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "overload"
@@ -1724,24 +1725,24 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "0ba30cc2c0cd02af1222ed216ba659cdb2f879dfe3181852fe7c50b1d0005949"
 dependencies = [
  "base64",
  "bytes",
@@ -1809,9 +1810,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
+version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -1844,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "rusty-fork"
@@ -1862,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "same-file"
@@ -1892,9 +1893,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "sct"
@@ -1965,14 +1966,14 @@ checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.4",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
@@ -2067,9 +2068,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -2083,9 +2084,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dccf47db1b41fa1573ed27ccf5e08e3ca771cb994f776668c5ebda893b248fc"
+checksum = "b5d6e0250b93c8427a177b849d144a96d5acc57006149479403d7861ab721e34"
 dependencies = [
  "lock_api",
 ]
@@ -2103,9 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9249290c05928352f71c077cc44a464d880c63f26f7534728cca008e135c0428"
+checksum = "f8de3b03a925878ed54a954f621e64bf55a3c1bd29652d0d1a17830405350188"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2113,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbc16ddba161afc99e14d1713a453747a2b07fc097d2009f4c300ec99286105"
+checksum = "fa8241483a83a3f33aa5fff7e7d9def398ff9990b2752b6c6112b83c6d246029"
 dependencies = [
  "ahash",
  "atoi",
@@ -2161,9 +2162,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b850fa514dc11f2ee85be9d055c512aa866746adfacd1cb42d867d68e6a5b0d9"
+checksum = "9966e64ae989e7e575b19d7265cb79d7fc3cbbdf179835cb0d716f294c2049c9"
 dependencies = [
  "dotenvy",
  "either",
@@ -2183,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-rt"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c5b2d25fa654cc5f841750b8e1cdedbe21189bf9a9382ee90bfa9dd3562396"
+checksum = "804d3f245f894e61b1e6263c84b23ca675d96753b5abfd5cc8597d86806e8024"
 dependencies = [
  "once_cell",
  "tokio",
@@ -2210,9 +2211,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structmeta"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd9c2155aa89fb2c2cb87d99a610c689e7c47099b3e9f1c8a8f53faf4e3d2e3"
+checksum = "104842d6278bf64aa9d2f182ba4bde31e8aec7a131d29b7f444bb9b344a09e2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2222,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "structmeta-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafede0d0a2f21910f36d47b1558caae3076ed80f6f3ad0fc85a91e6ba7e5938"
+checksum = "24420be405b590e2d746d83b01f09af673270cf80e9b003a5fa7b651c58c7d93"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2272,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8234ae35e70582bfa0f1fedffa6daa248e41dd045310b19800c4a36382c8f60"
+checksum = "2c622ae390c9302e214c31013517c2061ecb2699935882c60a9b37f82f8625ae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2352,7 +2353,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -2624,15 +2625,15 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -2722,12 +2723,11 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
@@ -2880,6 +2880,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2905,9 +2914,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -2920,45 +2929,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,13 +30,13 @@ checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "async-trait"
-version = "0.1.66"
+version = "0.1.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
+checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.3",
 ]
 
 [[package]]
@@ -67,13 +67,13 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "automod"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab6689c4ab36fd9302672c093252aee665e97a7cb6508c194da6f9859866837"
+checksum = "2820ec8709207251544277a96c4e97692107868a6c6096f2c8e0b32b66e942d6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.3",
 ]
 
 [[package]]
@@ -111,6 +111,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
 
 [[package]]
 name = "block-buffer"
@@ -224,11 +230,11 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.8"
+version = "4.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
+checksum = "42dfd32784433290c51d92c438bb72ea5063797fc3cc9a21a8c4346bebbb2098"
 dependencies = [
- "bitflags",
+ "bitflags 2.0.2",
  "clap_derive",
  "clap_lex",
  "is-terminal",
@@ -239,15 +245,15 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.8"
+version = "4.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
+checksum = "fddf67631444a3a3e3e5ac51c36a5e01335302de677bd78759eaa90ab1f46644"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -391,7 +397,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -408,7 +414,7 @@ checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -419,7 +425,7 @@ checksum = "d358e0ec5c59a5e1603b933def447096886121660fc680dc1e64a0753981fe3c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -430,7 +436,7 @@ checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -443,7 +449,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -458,22 +464,22 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
 dependencies = [
  "libc",
  "redox_users",
- "winapi",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -660,7 +666,7 @@ checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -723,7 +729,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -845,7 +851,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "inotify-sys",
  "libc",
 ]
@@ -945,7 +951,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
 ]
 
@@ -1058,7 +1064,7 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ea850aa68a06e48fdb069c0ec44d0d64c8dbffa49bf3b6f7f0a901fdea1ba9"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -1214,7 +1220,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1250,7 +1256,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -1267,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
@@ -1281,7 +1287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
 dependencies = [
  "bit-set",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "lazy_static",
  "num-traits",
@@ -1309,9 +1315,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1361,7 +1367,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1429,7 +1435,7 @@ version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -1534,22 +1540,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.156"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
+checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.156"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
+checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.3",
 ]
 
 [[package]]
@@ -1680,7 +1686,7 @@ checksum = "dcbc16ddba161afc99e14d1713a453747a2b07fc097d2009f4c300ec99286105"
 dependencies = [
  "ahash",
  "atoi",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "bytes",
  "crc",
@@ -1738,7 +1744,7 @@ dependencies = [
  "sha2",
  "sqlx-core",
  "sqlx-rt",
- "syn",
+ "syn 1.0.109",
  "url",
 ]
 
@@ -1778,7 +1784,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1789,7 +1795,7 @@ checksum = "bafede0d0a2f21910f36d47b1558caae3076ed80f6f3ad0fc85a91e6ba7e5938"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1811,7 +1817,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1825,6 +1831,17 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8234ae35e70582bfa0f1fedffa6daa248e41dd045310b19800c4a36382c8f60"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1882,27 +1899,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.3",
 ]
 
 [[package]]
@@ -1996,7 +2013,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2063,7 +2080,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2278,7 +2295,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -2300,7 +2317,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,7 @@ name = "broker"
 version = "0.1.0-pre"
 dependencies = [
  "async-trait",
+ "atty",
  "automod",
  "base64",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ automod = "1.0.8"
 tokio-retry = "0.3.0"
 bincode = "1.3.3"
 uuid = { version = "1.3.0", features = ["v4"] }
+atty = "0.2.14"
 
 [dev-dependencies]
 insta = { version = "1.28.0", features = ["filters", "json", "yaml"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ async-trait = "0.1.66"
 semver = { version = "1.0.17", features = ["serde"] }
 tap = "1.0.1"
 automod = "1.0.7"
+tokio-retry = "0.3.0"
 
 [dev-dependencies]
 insta = { version = "1.28.0", features = ["filters", "json", "yaml"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ publish = false # rather than publishing this to crates.io, we'll provide releas
 
 [dependencies]
 bytesize = { version = "1.2.0", features = ["serde"] }
-clap = { version = "4.1.8", features = ["derive", "cargo", "env"] }
+clap = { version = "4.1.11", features = ["derive", "cargo", "env"] }
 colored = "2.0.0"
 delegate = "0.9.0"
 derive-new = "0.5.9"
 derive_more = "0.99.17"
-dirs = "4.0.0"
+dirs = "5.0.0"
 error-stack = { version = "0.3.1", features = ["spantrace", "hooks"] }
 futures = "0.3.27"
 getset = "0.1.2"
@@ -26,12 +26,12 @@ indoc = "2.0.1"
 once_cell = "1.17.1"
 rolling-file = "0.2.0"
 secrecy = { version = "0.8.0", features = ["serde"] }
-serde = { version = "1.0.156", features = ["derive"] }
+serde = { version = "1.0.158", features = ["derive"] }
 strum = { version = "0.24.1", features = ["derive"] }
 subtle = "2.5.0"
 tempfile = "3.4.0"
 serde_yaml = "0.9.19"
-thiserror = "1.0.39"
+thiserror = "1.0.40"
 tokio = { version = "1.26.0", features = ["full", "fs"] }
 tracing = "0.1.37"
 tracing-appender = "0.2.2"
@@ -42,10 +42,10 @@ itertools = "0.10.5"
 time = { version = "0.3.20", features = ["parsing"] }
 yaque = "0.6.4"
 sqlx = { version = "0.6.2", features = ["runtime-tokio-rustls", "sqlite", "migrate", "macros", "time", "offline"] }
-async-trait = "0.1.66"
+async-trait = "0.1.67"
 semver = { version = "1.0.17", features = ["serde"] }
 tap = "1.0.1"
-automod = "1.0.7"
+automod = "1.0.8"
 tokio-retry = "0.3.0"
 bincode = "1.3.3"
 uuid = { version = "1.3.0", features = ["v4"] }
@@ -58,7 +58,7 @@ test-strategy = "0.3.0"
 
 [build-dependencies]
 error-stack = { version = "0.3.1", features = ["hooks"] }
-thiserror = "1.0.39"
+thiserror = "1.0.40"
 
 [profile.dist]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ semver = { version = "1.0.17", features = ["serde"] }
 tap = "1.0.1"
 automod = "1.0.7"
 tokio-retry = "0.3.0"
+bincode = "1.3.3"
+uuid = { version = "1.3.0", features = ["v4"] }
 
 [dev-dependencies]
 insta = { version = "1.28.0", features = ["filters", "json", "yaml"] }

--- a/src/api/http.rs
+++ b/src/api/http.rs
@@ -1,12 +1,15 @@
 //! Interact with remote services over HTTP!
 
+use std::fmt::Display;
+
 use derive_more::From;
 use derive_new::new;
+use serde::{Deserialize, Serialize};
 
 use crate::ext::secrecy::ComparableSecretString;
 
 /// HTTP authentication can be performed either with a header or via 'HTTP Basic'.
-#[derive(Debug, Clone, PartialEq, Eq, From, new)]
+#[derive(Debug, Clone, PartialEq, Eq, From, Deserialize, Serialize, new)]
 pub enum Auth {
     /// Uses a header value for authentication.
     Header(ComparableSecretString),
@@ -19,4 +22,15 @@ pub enum Auth {
         /// The password for authentication.
         password: ComparableSecretString,
     },
+}
+
+impl Display for Auth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Auth::Header(header) => write!(f, "authorization header {header}"),
+            Auth::Basic { username, password } => {
+                write!(f, "username '{username}' and password '{password}'")
+            }
+        }
+    }
 }

--- a/src/api/remote/git.rs
+++ b/src/api/remote/git.rs
@@ -1,9 +1,12 @@
 pub mod repository;
 pub mod transport;
+use std::fmt::Display;
+
 use derive_new::new;
+use serde::{Deserialize, Serialize};
 
 /// A git reference's type (branch or tag)
-#[derive(Debug, Clone, Hash, Eq, PartialEq, new)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, new)]
 pub enum Reference {
     /// A branch
     Branch {
@@ -23,11 +26,41 @@ pub enum Reference {
     },
 }
 
+impl Display for Reference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Reference::Branch { name, head } => {
+                write!(f, "branch '{name}' with head commit '{head}'")
+            }
+            Reference::Tag { name, commit } => {
+                write!(f, "tag '{name}' referencing commit '{commit}'")
+            }
+        }
+    }
+}
+
 impl Reference {
     fn name(&self) -> &String {
         match self {
             Self::Branch { name, .. } => name,
             Self::Tag { name, .. } => name,
+        }
+    }
+
+    /// Generate a canonical state for the reference.
+    pub fn as_state(&self) -> &[u8] {
+        match self {
+            Reference::Branch { head, .. } => head.as_bytes(),
+            Reference::Tag { commit, .. } => commit.as_bytes(),
+        }
+    }
+
+    /// Generate a representation for the reference suitable for use when
+    /// creating database coordinates.
+    pub fn for_coordinate(&self) -> String {
+        match self {
+            Reference::Branch { name, head } => format!("branch:{name}@{head}"),
+            Reference::Tag { name, commit } => format!("tag:{name}@{commit}"),
         }
     }
 }

--- a/src/api/remote/git/transport.rs
+++ b/src/api/remote/git/transport.rs
@@ -103,7 +103,7 @@ impl RemoteProvider for Transport {
         // The cost is irrelevant next to the IO time.
         let transport = self.to_owned();
         let reference = reference.to_owned();
-        io::spawn_blocking_stacked(move || repository::clone_reference(&transport, &reference))
+        io::spawn_blocking(move || repository::clone_reference(&transport, &reference))
             .await
             .change_context(RemoteProviderError::RunCommand)
     }
@@ -114,7 +114,7 @@ impl RemoteProvider for Transport {
         // Rather than get into tracking lifetimes, just clone it.
         // The cost is irrelevant next to the IO time.
         let transport = self.to_owned();
-        io::spawn_blocking_stacked(move || repository::list_references(&transport))
+        io::spawn_blocking(move || repository::list_references(&transport))
             .await
             .change_context(RemoteProviderError::RunCommand)
     }

--- a/src/api/ssh.rs
+++ b/src/api/ssh.rs
@@ -1,18 +1,28 @@
 //! Interact with remote services over SSH.
 
-use std::path::PathBuf;
+use std::{fmt::Display, path::PathBuf};
 
 use derive_more::From;
 use derive_new::new;
+use serde::{Deserialize, Serialize};
 
 use crate::ext::secrecy::ComparableSecretString;
 
 /// SSH authentication can be performed either with a key file or with a static key.
-#[derive(Debug, Clone, PartialEq, Eq, From, new)]
+#[derive(Debug, Clone, PartialEq, Eq, From, Deserialize, Serialize, new)]
 pub enum Auth {
     /// Uses a key file on disk to perform authentication.
     KeyFile(PathBuf),
 
     /// Uses a value stored in the config file (and therefore in memory) to perform authentication.
     KeyValue(ComparableSecretString),
+}
+
+impl Display for Auth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Auth::KeyFile(path) => write!(f, "key file at {path:?}"),
+            Auth::KeyValue(key) => write!(f, "private key {key}"),
+        }
+    }
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -82,7 +82,7 @@ pub struct Config {
     debug: debug::Config,
 
     /// Configured integration points.
-    integrations: api::remote::Config,
+    integrations: api::remote::Integrations,
 }
 
 impl Config {

--- a/src/config/file/v1.rs
+++ b/src/config/file/v1.rs
@@ -71,7 +71,7 @@ fn validate(config: RawConfigV1) -> Result<super::Config, Report<Error>> {
         .map(remote::Integration::try_from)
         .collect::<Result<Vec<_>, Report<remote::ValidationError>>>()
         .change_context(Error::Validate)
-        .map(remote::Config::new)?;
+        .map(remote::Integrations::new)?;
 
     super::Config::new(api, debugging, integrations).wrap_ok()
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -98,7 +98,7 @@ impl Config {
             .with(
                 tracing_subscriber::fmt::layer()
                     .pretty()
-                    .with_filter(filter::LevelFilter::INFO),
+                    .with_filter(filter::LevelFilter::WARN),
             )
             // log all traces to file in json format
             .with(

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -98,7 +98,7 @@ impl Config {
             .with(
                 tracing_subscriber::fmt::layer()
                     .pretty()
-                    .with_filter(filter::LevelFilter::WARN),
+                    .with_filter(filter::LevelFilter::INFO),
             )
             // log all traces to file in json format
             .with(

--- a/src/download_fossa_cli.rs
+++ b/src/download_fossa_cli.rs
@@ -69,7 +69,7 @@ pub async fn ensure_fossa_cli() -> Result<PathBuf, Error> {
     };
 
     // if it is not in either location, then download it
-    download(&data_root)
+    download(data_root)
         .await
         .describe("fossa-cli not found in your path, attempting to download it")
 }

--- a/src/ext/error_stack.rs
+++ b/src/ext/error_stack.rs
@@ -16,6 +16,14 @@ macro_rules! merge_error_stacks {
 
 pub(crate) use merge_error_stacks;
 
+/// Merge multiple error stacks together into a single combined stack.
+pub fn merge_errors<I: IntoIterator<Item = Report<E>>, E>(errs: I) -> Option<Report<E>> {
+    errs.into_iter().reduce(|mut stack, err| {
+        stack.extend_one(err);
+        stack
+    })
+}
+
 /// Used to provide help text to an error.
 ///
 /// This is meant to be readable by users of the application;

--- a/src/ext/io.rs
+++ b/src/ext/io.rs
@@ -31,7 +31,7 @@ use tokio::task;
 use crate::ext::error_stack::{DescribeContext, ErrorHelper, IntoContext};
 
 pub mod sync;
-pub use sync::DATA_ROOT_VAR;
+pub use sync::set_data_root;
 
 /// Errors that are possibly surfaced during IO actions.
 #[derive(Debug, thiserror::Error)]
@@ -53,7 +53,7 @@ pub enum Error {
 ///
 /// Users may also customize this root via the [`DATA_ROOT_VAR`] environment variable.
 #[tracing::instrument]
-pub async fn data_root() -> Result<PathBuf, Report<Error>> {
+pub async fn data_root() -> Result<&'static PathBuf, Report<Error>> {
     run_background(sync::data_root).await
 }
 
@@ -134,23 +134,24 @@ where
         .change_context(Error::IO)
 }
 
-/// Run the provided blocking closure in the background,
-/// wrapping any error returned in this module's `Error::IO` context.
+/// Run the provided blocking closure in the background.
+///
+/// The error returned by the function is wrapped inside a report
+/// and set to this module's `Error::IO` context.
 #[tracing::instrument(skip_all)]
-pub async fn spawn_blocking<T, E, F>(work: F) -> Result<T, Report<Error>>
+pub async fn spawn_blocking_wrap<T, E, F>(work: F) -> Result<T, Report<Error>>
 where
     T: Send + 'static,
     E: std::error::Error + Sync + Send + 'static,
     Report<E>: From<E>,
     F: FnOnce() -> Result<T, E> + Send + 'static,
 {
-    spawn_blocking_stacked(|| work().into_report()).await
+    spawn_blocking(|| work().into_report()).await
 }
 
-/// Run the provided blocking closure in the background,
-/// wrapping any error returned in this module's `Error::IO` context.
+/// Run the provided blocking closure in the background.
 #[tracing::instrument(skip_all)]
-pub async fn spawn_blocking_stacked<T, E, F>(work: F) -> Result<T, Report<Error>>
+pub async fn spawn_blocking<T, E, F>(work: F) -> Result<T, Report<Error>>
 where
     T: Send + 'static,
     E: Context,

--- a/src/ext/io.rs
+++ b/src/ext/io.rs
@@ -156,5 +156,5 @@ where
     E: Context,
     F: FnOnce() -> Result<T, Report<E>> + Send + 'static,
 {
-    run_background(|| work()).await
+    run_background(work).await
 }

--- a/src/ext/io.rs
+++ b/src/ext/io.rs
@@ -144,5 +144,17 @@ where
     Report<E>: From<E>,
     F: FnOnce() -> Result<T, E> + Send + 'static,
 {
-    run_background(|| work().into_report()).await
+    spawn_blocking_stacked(|| work().into_report()).await
+}
+
+/// Run the provided blocking closure in the background,
+/// wrapping any error returned in this module's `Error::IO` context.
+#[tracing::instrument(skip_all)]
+pub async fn spawn_blocking_stacked<T, E, F>(work: F) -> Result<T, Report<Error>>
+where
+    T: Send + 'static,
+    E: Context,
+    F: FnOnce() -> Result<T, Report<E>> + Send + 'static,
+{
+    run_background(|| work()).await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,12 @@
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]
 
+use atty::Stream;
 use broker::api::remote::RemoteProvider;
 use broker::db;
 use broker::doc::crate_version;
 use broker::download_fossa_cli;
+use broker::ext::error_stack::IntoContext;
 use broker::{config, ext::error_stack::ErrorHelper};
 use broker::{
     doc,
@@ -16,7 +18,8 @@ use broker::{
 };
 use clap::{Parser, Subcommand};
 use error_stack::{bail, fmt::ColorMode, Report, Result, ResultExt};
-use tracing::info;
+use tap::TapFallible;
+use tracing::debug;
 
 #[derive(Debug, thiserror::Error)]
 enum Error {
@@ -68,21 +71,54 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // App-wide setup goes here.
-    Report::set_color_mode(ColorMode::Color);
+    // App-wide setup that doesn't depend on config or subcommand goes here.
     let version = crate_version();
+    if atty::is(Stream::Stdout) {
+        Report::set_color_mode(ColorMode::Color);
+    } else {
+        Report::set_color_mode(ColorMode::None);
+    }
 
     // Subcommand routing.
     let Opts { command } = Opts::parse();
-    match command {
-        Commands::Init => main_init().await,
-        Commands::Setup => main_setup().await,
-        Commands::Config(args) => main_config(args).await,
-        Commands::Fix(args) => main_fix(args).await,
-        Commands::Backup(args) => main_backup(args).await,
-        Commands::Run(args) => main_run(args).await,
-        Commands::Clone(args) => main_clone(args).await,
+    let subcommand = || async {
+        match command {
+            Commands::Init => main_init().await,
+            Commands::Setup => main_setup().await,
+            Commands::Config(args) => main_config(args).await,
+            Commands::Fix(args) => main_fix(args).await,
+            Commands::Backup(args) => main_backup(args).await,
+            Commands::Run(args) => main_run(args).await,
+            Commands::Clone(args) => main_clone(args).await,
+        }
+    };
+
+    // Run the subcommand, but also listen for ctrl+c.
+    // If ctrl+c is fired, we exit; this drops any futures currently running.
+    // In Rust, this is the appropriate way to cancel futures.
+    tokio::select! {
+        // We want to handle signals first, regardless of how often the subcommand
+        // is ready to be polled.
+        biased;
+
+        // If the signal fires, log that we're shutting down and return.
+        result = tokio::signal::ctrl_c() => {
+            // Only log this on success.
+            //
+            // Write directly to stderr because tracing may already be shut down,
+            // or may not ever have been started, by the time this runs.
+            result.tap_ok(|_| eprintln!("Shut down at due to OS signal"))
+            // If this errors, it'll do so immediately before anything else runs,
+            // so it's definitely part of internal setup.
+            .context(Error::InternalSetup)
+        },
+
+        // Otherwise, run the subcommand to completion.
+        result = subcommand() => {
+            result
+        }
     }
+    // Decorate any error message with top level diagnostics and debugging help.
     .request_support()
     .describe_lazy(|| format!("broker version: {version}"))
 }
@@ -124,6 +160,7 @@ async fn main_run(args: config::RawBaseArgs) -> Result<(), Error> {
         .await
         .change_context(Error::DetermineEffectiveConfig)
         .documentation_lazy(doc::link::config_file_reference)?;
+    debug!("Loaded {conf:?}");
 
     let _tracing_guard = conf
         .debug()
@@ -137,9 +174,9 @@ async fn main_run(args: config::RawBaseArgs) -> Result<(), Error> {
     let fossa_path = download_fossa_cli::ensure_fossa_cli()
         .await
         .change_context(Error::InternalSetup)?;
-    info!("fossa path: {:?}", fossa_path);
+    debug!("fossa path: {:?}", fossa_path);
 
-    info!("Loaded {conf:?}");
+    debug!("Loaded {conf:?}");
     broker::subcommand::run::main(conf, db)
         .await
         .change_context(Error::Runtime)

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,7 @@ async fn main_clone(args: config::RawBaseArgs) -> Result<(), Error> {
 
     let integration = &conf.integrations().as_ref()[0];
     let mut references = integration.references()
+        .await
         .change_context(Error::Runtime)
         .help("try running Broker with the '--help' argument to see available options and usage suggestions")?;
 
@@ -168,6 +169,7 @@ async fn main_clone(args: config::RawBaseArgs) -> Result<(), Error> {
     for reference in references {
         integration
             .clone_reference(&reference)
+            .await
             .change_context(Error::Runtime)?;
     }
     Ok(())

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -29,6 +29,9 @@ pub enum Error {
 pub enum Queue {
     /// This queue is just used to send and log messages, used to demonstrate it's working.
     Echo,
+
+    /// The queue for scanning revisions.
+    Scan,
 }
 
 /// Open both sides of the named queue.

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,10 +1,10 @@
 //! Async work queue implementation.
 
-use std::{fmt::Debug, ops::Deref, path::PathBuf};
+use std::{fmt::Debug, marker::PhantomData, ops::Deref, path::PathBuf};
 
-use derive_more::From;
 use error_stack::{Report, ResultExt};
 use indoc::{formatdoc, indoc};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use strum::Display;
 
 use crate::ext::{
@@ -22,6 +22,16 @@ pub enum Error {
     /// Couldn't construct the queue, which usually means that the named queue is already in use.
     #[error("open queue")]
     Open,
+
+    /// When sending to the queue, the item is serialized.
+    /// If that serialize operation fails, this error is returned.
+    #[error("serialize item")]
+    Serialize,
+
+    /// When receiving from the queue, the item is deserialized.
+    /// If that deserialize operation fails, this error is returned.
+    #[error("deserialize item")]
+    Deserialize,
 }
 
 /// Queues supported by the application.
@@ -35,7 +45,10 @@ pub enum Queue {
 }
 
 /// Open both sides of the named queue.
-pub async fn open(queue: Queue) -> Result<(Sender, Receiver), Report<Error>> {
+pub async fn open<'a, T>(queue: Queue) -> Result<(Sender<T>, Receiver<T>), Report<Error>>
+where
+    T: Serialize + Deserialize<'a>,
+{
     let location = queue_location(queue).await?;
     tokio::try_join!(
         Sender::open_internal(location.clone()),
@@ -51,15 +64,28 @@ async fn queue_location(queue: Queue) -> Result<PathBuf, Report<Error>> {
 }
 
 /// The sender side of the queue.
-pub struct Sender(yaque::Sender);
+pub struct Sender<T> {
+    t: PhantomData<T>,
+    internal: yaque::Sender,
+}
 
-impl Debug for Sender {
+impl<T> Debug for Sender<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("Sender([OPAQUE yaque::Sender])")
     }
 }
 
-impl Sender {
+impl<T> Sender<T>
+where
+    T: Serialize,
+{
+    fn new(internal: yaque::Sender) -> Self {
+        Self {
+            t: PhantomData::default(),
+            internal,
+        }
+    }
+
     /// Opens the named queue for sending.
     ///
     /// # Access
@@ -76,6 +102,19 @@ impl Sender {
         Self::open_internal(path).await
     }
 
+    /// Sends an item into the queue. One send is always atomic. This function is
+    /// `async` because the queue might be full and so we need to `.await` the
+    /// receiver to consume enough segments to clear the queue.
+    ///
+    /// # Errors
+    ///
+    /// This function returns any underlying errors encountered while writing or
+    /// flushing the queue, or while encoding the type.
+    pub async fn send(&mut self, item: &T) -> Result<(), Report<Error>> {
+        let encoded = bincode::serialize(item).context(Error::Serialize)?;
+        self.send_internal(&encoded).await
+    }
+
     /// Sends some data into the queue. One send is always atomic. This function is
     /// `async` because the queue might be full and so we need to `.await` the
     /// receiver to consume enough segments to clear the queue.
@@ -84,13 +123,13 @@ impl Sender {
     ///
     /// This function returns any underlying errors encountered while writing or
     /// flushing the queue.
-    pub async fn send(&mut self, data: &[u8]) -> Result<(), Report<Error>> {
-        self.0.send(data).await.context(Error::IO)
+    async fn send_internal(&mut self, data: &[u8]) -> Result<(), Report<Error>> {
+        self.internal.send(data).await.context(Error::IO)
     }
 
     async fn open_internal(path: PathBuf) -> Result<Self, Report<Error>> {
         let lock_path = path.join("send.lock");
-        io::spawn_blocking(move || yaque::Sender::open(path))
+        io::spawn_blocking_wrap(move || yaque::Sender::open(path))
             .await
             .change_context(Error::Open)
             .help(indoc! {"
@@ -101,20 +140,33 @@ impl Sender {
             Queue working state is stored on disk, and relies on a lockfile to guard access.
             For this particular queue, this lock file is located at {lock_path:?}.
             "})
-            .map(Self)
+            .map(Self::new)
     }
 }
 
 /// The receiver side of the queue.
-pub struct Receiver(yaque::Receiver);
+pub struct Receiver<T> {
+    t: PhantomData<T>,
+    internal: yaque::Receiver,
+}
 
-impl Debug for Receiver {
+impl<T> Debug for Receiver<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("Receiver([OPAQUE yaque::Receiver])")
     }
 }
 
-impl Receiver {
+impl<'a, T> Receiver<T>
+where
+    T: Deserialize<'a>,
+{
+    fn new(internal: yaque::Receiver) -> Self {
+        Self {
+            t: PhantomData::default(),
+            internal,
+        }
+    }
+
     /// Opens the named queue for sending.
     ///
     /// # Access
@@ -148,13 +200,17 @@ impl Receiver {
     /// This function will panic if it has to start reading a new segment and
     /// it is not able to set up the notification handler to watch for file
     /// changes.
-    pub async fn recv(&mut self) -> Result<RecvGuard<'_>, Report<Error>> {
-        self.0.recv().await.context(Error::IO).map(RecvGuard::from)
+    pub async fn recv(&mut self) -> Result<RecvGuard<'_, T>, Report<Error>> {
+        self.internal
+            .recv()
+            .await
+            .context(Error::IO)
+            .map(RecvGuard::from)
     }
 
     async fn open_internal(path: PathBuf) -> Result<Self, Report<Error>> {
         let lock_path = path.join("recv.lock");
-        io::spawn_blocking(move || yaque::Receiver::open(path))
+        io::spawn_blocking_wrap(move || yaque::Receiver::open(path))
             .await
             .change_context(Error::Open)
             .help(indoc! {"
@@ -165,7 +221,7 @@ impl Receiver {
             Queue working state is stored on disk, and relies on a lockfile to guard access.
             For this particular queue, this lock file is located at {lock_path:?}.
             "})
-            .map(Self)
+            .map(Self::new)
     }
 }
 
@@ -176,13 +232,18 @@ impl Receiver {
 /// during rollback, the state will be committed. If you *can* do something
 /// with the IO error, you may use `RecvGuard::rollback` explicitly to catch
 /// the error.
-#[derive(From)]
-pub struct RecvGuard<'a>(yaque::queue::RecvGuard<'a, Vec<u8>>);
+pub struct RecvGuard<'a, T> {
+    t: PhantomData<T>,
+    internal: yaque::queue::RecvGuard<'a, Vec<u8>>,
+}
 
-impl<'a> RecvGuard<'a> {
+impl<'a, T> RecvGuard<'a, T>
+where
+    T: DeserializeOwned,
+{
     /// Commits the changes to the queue, consuming this `RecvGuard`.
     pub fn commit(self) -> Result<(), Report<Error>> {
-        self.0.commit().context(Error::IO)
+        self.internal.commit().context(Error::IO)
     }
 
     /// Rolls the reader back to the previous point, negating the changes made
@@ -195,12 +256,26 @@ impl<'a> RecvGuard<'a> {
     /// If there is some error while moving the reader back, this error will be
     /// return.
     pub fn rollback(self) -> Result<(), Report<Error>> {
-        self.0.rollback().context(Error::IO)
+        self.internal.rollback().context(Error::IO)
     }
 
-    /// Returns a reference to the element received.
-    pub fn data(&self) -> &[u8] {
-        self.0.deref()
+    /// Returns a decoded form of the element received.
+    pub fn item(&self) -> Result<T, Report<Error>> {
+        bincode::deserialize(self.data()).context(Error::Deserialize)
+    }
+
+    /// Returns a reference to the encoded element received.
+    fn data(&self) -> &[u8] {
+        self.internal.deref()
+    }
+}
+
+impl<'a, T> From<yaque::queue::RecvGuard<'a, Vec<u8>>> for RecvGuard<'a, T> {
+    fn from(internal: yaque::queue::RecvGuard<'a, Vec<u8>>) -> Self {
+        Self {
+            t: PhantomData::default(),
+            internal,
+        }
     }
 }
 
@@ -220,7 +295,7 @@ mod tests {
         let tmp = tempdir().expect("must create temporary directory");
 
         // Keep this variable around for the duration of the test: the lockfile is removed on drop.
-        let _tx = Sender::open_internal(tmp.path().to_path_buf())
+        let _tx: Sender<Vec<u8>> = Sender::open_internal(tmp.path().to_path_buf())
             .await
             .expect("must open receiver");
 
@@ -239,7 +314,7 @@ mod tests {
         let tmp = tempdir().expect("must create temporary directory");
 
         // Keep this variable around for the duration of the test: the lockfile is removed on drop.
-        let _rx = Receiver::open_internal(tmp.path().to_path_buf())
+        let _rx: Receiver<Vec<u8>> = Receiver::open_internal(tmp.path().to_path_buf())
             .await
             .expect("must open receiver");
 

--- a/src/subcommand/run.rs
+++ b/src/subcommand/run.rs
@@ -1,17 +1,26 @@
 //! Implementation for the `run` subcommand.
 
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
-use error_stack::{Result, ResultExt};
-use futures::try_join;
-use tracing::info;
+use backon::ExponentialBuilder;
+use backon::Retryable;
+use error_stack::{Report, Result, ResultExt};
+use futures::{future::try_join_all, try_join, StreamExt};
+use tap::TapFallible;
+use tokio_retry::strategy::jitter;
+use tokio_retry::strategy::ExponentialBackoff;
+use tokio_retry::Retry;
+use tracing::debug;
+use tracing::warn;
 
 use crate::{
+    api::remote::{Integration, RemoteProvider},
     config::Config,
     db::Database,
     ext::{
-        error_stack::{DescribeContext, ErrorHelper},
-        result::DiscardResult,
+        error_stack::{merge_error_stacks, merge_errors, DescribeContext, ErrorHelper},
+        io,
+        result::{DiscardResult, WrapErr},
     },
 };
 
@@ -21,47 +30,98 @@ pub enum Error {
     /// Application health check failed.
     #[error("health check failed")]
     Healthcheck,
+
+    /// The application periodically polls for new references in configured integrations.
+    /// If one of those polls fails, this error is returned.
+    #[error("poll integration")]
+    PollIntegration,
 }
 
 /// The primary entrypoint.
 #[tracing::instrument(skip_all)]
-pub async fn main(_config: Config, db: impl Database) -> Result<(), Error> {
-    info!("Broker will run until it is terminated, but isn't doing anything special: this subcommand is still basically NYI");
-    try_join!(do_pretend_work(), do_healthcheck(db)).discard_ok()
-}
+pub async fn main(config: Config, db: impl Database) -> Result<(), Error> {
+    // This function runs a bunch of async background tasks.
+    // Create them all, then just `try_join!` on all of them at the end.
+    let integration_worker = do_poll_integrations(&config, &db);
+    let healthcheck_worker = do_healthcheck(&db);
 
-#[tracing::instrument]
-async fn do_pretend_work() -> Result<(), Error> {
-    for i in 0.. {
-        tokio::time::sleep(Duration::from_secs(10)).await;
-        do_pretend_work_cycle(i).await;
-    }
-    Ok(())
-}
-
-#[tracing::instrument]
-async fn do_pretend_work_cycle(cycle: usize) {
-    info!("Yep, still running{}", "!".repeat(cycle % 5));
+    // `try_join!` keeps all of the workers running until one of them fails,
+    // at which point the failure is returned and remaining tasks are dropped.
+    // It also returns all of their results as a tuple, which we don't care about,
+    // so we discard that value.
+    try_join!(integration_worker, healthcheck_worker).discard_ok()
 }
 
 /// Conduct internal diagnostics to ensure Broker is still in a good state.
 #[tracing::instrument]
-async fn do_healthcheck(db: impl Database) -> Result<(), Error> {
-    do_healthcheck_cycle(&db).await?;
-
+async fn do_healthcheck(db: &impl Database) -> Result<(), Error> {
     for _ in 0.. {
+        db.healthcheck()
+            .await
+            .tap_ok(|_| debug!("db healtheck ok"))
+            .change_context(Error::Healthcheck)
+            .describe("Broker periodically runs internal healthchecks to validate that it is still in a good state")
+            .help("this health check failing may have been related to a temporary condition, restarting Broker may resolve the issue")?;
+
         tokio::time::sleep(Duration::from_secs(60)).await;
-        do_healthcheck_cycle(&db).await?;
     }
 
     Ok(())
 }
 
-#[tracing::instrument]
-async fn do_healthcheck_cycle(db: &impl Database) -> Result<(), Error> {
-    db.healthcheck()
-        .await
-        .change_context(Error::Healthcheck)
-        .describe("Broker periodically runs internal healthchecks to validate that it is still in a good state")
-        .help("this health check failing may have been related to a temporary condition, restarting Broker may resolve the issue")
+/// Loops forever, polling configured integrations on their `poll_interval`.
+async fn do_poll_integrations(config: &Config, db: &impl Database) -> Result<(), Error> {
+    // Each integration is configured with a poll interval.
+    // Rather than have one big poll loop that has to track polling times for each integration,
+    // just create a task per integration; they're cheap.
+    let integration_workers = config
+        .integrations()
+        .iter()
+        .map(|integration| async { do_poll_integration(config, db, integration).await });
+
+    // Run all the workers in parallel. If one errors, return that error and drop the rest.
+    try_join_all(integration_workers).await.discard_ok()
+}
+
+async fn do_poll_integration(
+    config: &Config,
+    db: &impl Database,
+    integration: &Integration,
+) -> Result<(), Error> {
+    let get_references = || async {
+        match integration.references().await {
+            Ok(success) => Ok(success),
+            Err(err) => {
+                warn!("attempt to get references failed: {err:#}");
+                Err(err)
+            }
+        }
+    };
+
+    loop {
+        // It's possible for temporary issues to prevent polling.
+        // Rather than fail immediately on any polling error, keep going until we get too many failures in a row.
+        let strategy = ExponentialBackoff::from_millis(1000).map(jitter).take(5);
+        let references = Retry::spawn(strategy, get_references)
+            .await
+            .change_context(Error::PollIntegration)
+            .help("help_text")?;
+
+        // Then wait for the next poll time.
+        // The fact that we poll, _then_ wait for the poll time, means that the actual
+        // time at which the poll occurs will slowly creep forward by whatever time
+        // it takes to perform the poll.
+        //
+        // This is considered okay, because we're interpreting "poll interval" as
+        // "poll at most this often"; i.e. it's used primarily as a rate limiting feature
+        // than as a "track changes this often" feature.
+        //
+        // The alternative would be starting the clock at the top of the loop,
+        // which while doable could (in the worst case) allow for endlessly
+        // polling if the poll takes at least as long as the interval.
+        //
+        // If we decide to make polling more consistent, [`tokio::time::interval`]
+        // is most likely the correct way to implement it.
+        tokio::time::sleep(integration.poll_interval().as_duration()).await;
+    }
 }

--- a/src/subcommand/run.rs
+++ b/src/subcommand/run.rs
@@ -1,26 +1,32 @@
 //! Implementation for the `run` subcommand.
 
-use std::{collections::HashMap, time::Duration};
+use std::sync::Arc;
+use std::time::Duration;
 
-use backon::ExponentialBuilder;
-use backon::Retryable;
-use error_stack::{Report, Result, ResultExt};
+use error_stack::{Result, ResultExt};
+use futures::TryStreamExt;
 use futures::{future::try_join_all, try_join, StreamExt};
+use indoc::indoc;
+use serde::{Deserialize, Serialize};
 use tap::TapFallible;
+use tokio::sync::Mutex;
 use tokio_retry::strategy::jitter;
 use tokio_retry::strategy::ExponentialBackoff;
 use tokio_retry::Retry;
-use tracing::debug;
 use tracing::warn;
+use tracing::{debug, info};
+use uuid::Uuid;
 
+use crate::api::remote::Reference;
+use crate::ext::error_stack::IntoContext;
+use crate::queue::{self, Queue, Receiver, Sender};
 use crate::{
     api::remote::{Integration, RemoteProvider},
     config::Config,
     db::Database,
     ext::{
-        error_stack::{merge_error_stacks, merge_errors, DescribeContext, ErrorHelper},
-        io,
-        result::{DiscardResult, WrapErr},
+        error_stack::{DescribeContext, ErrorHelper},
+        result::DiscardResult,
     },
 };
 
@@ -31,25 +37,61 @@ pub enum Error {
     #[error("health check failed")]
     Healthcheck,
 
+    /// Setting up async pipeline failed.
+    #[error("set up task pipeline")]
+    SetupPipeline,
+
     /// The application periodically polls for new references in configured integrations.
     /// If one of those polls fails, this error is returned.
     #[error("poll integration")]
     PollIntegration,
+
+    /// When tasks are stored in the async pipeline, they must be encoded.
+    /// If they fail to encode, this is the resulting error.
+    #[error("task encoding failed")]
+    TaskEncode,
+
+    /// When tasks are stored in the async pipeline, they must be encoded.
+    /// If they fail to decode, this is the resulting error.
+    #[error("task decoding failed")]
+    TaskDecode,
+
+    /// If we fail to send tasks to the async task queue, this error is raised.
+    #[error("enqueue task for processing")]
+    TaskEnqueue,
+
+    /// If we fail to receive tasks to the async task queue, this error is raised.
+    #[error("receive task for processing")]
+    TaskReceive,
+
+    /// If we fail to mark a task complete, this error is raised.
+    #[error("mark task complete")]
+    TaskComplete,
 }
 
 /// The primary entrypoint.
 #[tracing::instrument(skip_all)]
 pub async fn main(config: Config, db: impl Database) -> Result<(), Error> {
+    let (scan_tx, scan_rx) = queue::open(Queue::Scan)
+        .await
+        .change_context(Error::SetupPipeline)?;
+
     // This function runs a bunch of async background tasks.
     // Create them all, then just `try_join!` on all of them at the end.
-    let integration_worker = do_poll_integrations(&config, &db);
     let healthcheck_worker = do_healthcheck(&db);
+    let integration_worker = do_poll_integrations(&config, &db, scan_tx);
+    let scan_git_reference_worker = do_scan_git_reference(&db, scan_rx);
 
     // `try_join!` keeps all of the workers running until one of them fails,
     // at which point the failure is returned and remaining tasks are dropped.
     // It also returns all of their results as a tuple, which we don't care about,
     // so we discard that value.
-    try_join!(integration_worker, healthcheck_worker).discard_ok()
+    try_join!(
+        healthcheck_worker,
+        integration_worker,
+        scan_git_reference_worker
+    )
+    .discard_ok()
 }
 
 /// Conduct internal diagnostics to ensure Broker is still in a good state.
@@ -69,45 +111,137 @@ async fn do_healthcheck(db: &impl Database) -> Result<(), Error> {
     Ok(())
 }
 
+/// Job for scanning git vcs
+#[derive(Debug, Deserialize, Serialize)]
+struct ScanGitVCSReference {
+    scan_id: String,
+    integration: Integration,
+    reference: Reference,
+}
+
+impl ScanGitVCSReference {
+    fn new(integration: &Integration, reference: &Reference) -> Self {
+        Self {
+            scan_id: Uuid::new_v4().to_string(),
+            integration: integration.to_owned(),
+            reference: reference.to_owned(),
+        }
+    }
+}
+
 /// Loops forever, polling configured integrations on their `poll_interval`.
-async fn do_poll_integrations(config: &Config, db: &impl Database) -> Result<(), Error> {
+async fn do_poll_integrations(
+    config: &Config,
+    db: &impl Database,
+    sender: Sender,
+) -> Result<(), Error> {
+    // The sender is not thread safe; ensure it's only run one at a time.
+    let sender = Arc::new(Mutex::new(sender));
+
     // Each integration is configured with a poll interval.
     // Rather than have one big poll loop that has to track polling times for each integration,
     // just create a task per integration; they're cheap.
     let integration_workers = config
         .integrations()
         .iter()
-        .map(|integration| async { do_poll_integration(config, db, integration).await });
+        .map(|integration| async { do_poll_integration(db, integration, sender.clone()).await });
 
     // Run all the workers in parallel. If one errors, return that error and drop the rest.
     try_join_all(integration_workers).await.discard_ok()
 }
 
 async fn do_poll_integration(
-    config: &Config,
     db: &impl Database,
     integration: &Integration,
+    sender: Arc<Mutex<Sender>>,
 ) -> Result<(), Error> {
+    // We use this in a few places and may send it across threads, so just clone it locally.
+    let remote = integration.remote().to_owned();
+    let poll_interval = integration.poll_interval().as_duration();
+
+    // [`Retry`] needs a function that runs without any arguments to perform the retry, so turn the method into a closure.
     let get_references = || async {
         match integration.references().await {
             Ok(success) => Ok(success),
             Err(err) => {
-                warn!("attempt to get references failed: {err:#}");
+                warn!("attempt to poll integration at {remote} failed: {err:#}");
                 Err(err)
             }
         }
     };
 
     loop {
-        // It's possible for temporary issues to prevent polling.
-        // Rather than fail immediately on any polling error, keep going until we get too many failures in a row.
-        let strategy = ExponentialBackoff::from_millis(1000).map(jitter).take(5);
+        // Given that this operation is not latency sensitive, and temporary neetwork issues can interfere,
+        // retry several times before permanently failing since a permanent failure means Broker shuts down
+        // entirely.
+        let strategy = ExponentialBackoff::from_millis(1000).map(jitter).take(1);
         let references = Retry::spawn(strategy, get_references)
             .await
             .change_context(Error::PollIntegration)
-            .help("help_text")?;
+            .describe_lazy(|| format!("poll for changes at {remote} in integration: {integration}"))
+            .help(indoc! {"
+            Issues with this process are usually related to network errors, but may be due to misconfiguration.
+            Each time this polling operation was attempted, it logged a warning; please review those
+            warnings in the logs for more details.
+            "})?;
 
-        // Then wait for the next poll time.
+        // Filter to the list of references that are new since we last saw them.
+        let references = futures::stream::iter(references.into_iter())
+            // Using `filter_map` instead of `filter` so that this closure gets ownership of `reference`,
+            // which makes binding it across an await point easier (no lifetimes to mess with).
+            .filter_map(|reference| async {
+                let coordinate = reference.as_coordinate(&remote);
+                match db.state(&coordinate).await {
+                    // No previous state; this must be a new reference.
+                    Ok(None) => Some(Ok(reference)),
+                    // There was previous state, it's only new if the state is different.
+                    // We're assuming "different state" always means "newer state". 
+                    // This is because state is currently expressed as a git commit string,
+                    // which on its own doesn't have any form of ordering.
+                    Ok(Some(db_state)) => {
+                        if db_state == reference.as_state() {
+                            None
+                        } else {
+                            Some(Ok(reference))
+                        }
+                    }
+                    // Pass through errors.
+                    Err(err) => Some(Err(err)),
+                }
+            })
+            // Fold ourselves because `collect` expects its destination to implement `Default`.
+            .try_fold(Vec::new(), |mut references, reference| async {
+                references.push(reference);
+                Ok(references)
+            })
+            .await
+            .change_context(Error::PollIntegration)
+            .describe_lazy(|| {
+                format!("filter to only changes at {remote} in integration: {integration}")
+            })
+            .help(indoc! {"
+            Problems at this stage are most likely caused by a database error.
+            Broker manages a local sqlite database; deleting it so it can be re-generated from scratch may resolve the issue.
+            "})?;
+
+        // We sink the references here instead of during the stream so that
+        // if an error is encountered reading the stream, we don't send partial lists.
+        if references.is_empty() {
+            info!("No changes to {integration} since last poll interval");
+        }
+        for reference in references {
+            let job = ScanGitVCSReference::new(integration, &reference);
+            let encoded = bincode::serialize(&job).context(Error::TaskEncode)?;
+            let mut sender = sender.lock().await;
+            sender
+                .send(&encoded)
+                .await
+                .change_context(Error::TaskEnqueue)?;
+
+            info!("Enqueued task to scan {integration} at {reference}");
+        }
+
+        // Now wait for the next poll time.
         // The fact that we poll, _then_ wait for the poll time, means that the actual
         // time at which the poll occurs will slowly creep forward by whatever time
         // it takes to perform the poll.
@@ -122,6 +256,20 @@ async fn do_poll_integration(
         //
         // If we decide to make polling more consistent, [`tokio::time::interval`]
         // is most likely the correct way to implement it.
-        tokio::time::sleep(integration.poll_interval().as_duration()).await;
+
+        info!("Next poll interval for {integration} in {poll_interval:?}");
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+async fn do_scan_git_reference(_db: &impl Database, mut receiver: Receiver) -> Result<(), Error> {
+    loop {
+        let guard = receiver.recv().await.change_context(Error::TaskReceive)?;
+
+        let data = guard.data();
+        let job = bincode::deserialize::<ScanGitVCSReference>(data).context(Error::TaskDecode)?;
+
+        info!("Pretending to scan {job:?}");
+        guard.commit().change_context(Error::TaskComplete)?;
     }
 }

--- a/src/subcommand/run.rs
+++ b/src/subcommand/run.rs
@@ -174,7 +174,7 @@ async fn do_poll_integration(
     };
 
     loop {
-        // Given that this operation is not latency sensitive, and temporary neetwork issues can interfere,
+        // Given that this operation is not latency sensitive, and temporary network issues can interfere,
         // retry several times before permanently failing since a permanent failure means Broker shuts down
         // entirely.
         let strategy = ExponentialBackoff::from_millis(1000).map(jitter).take(1);

--- a/tests/it/args.rs
+++ b/tests/it/args.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use broker::{
     api::fossa::{Endpoint, Key},
-    config,
+    config::{self, RawBaseArgs},
 };
 use proptest::{prop_assert, prop_assert_eq};
 use url::Url;
@@ -10,8 +10,8 @@ use url::Url;
 use crate::helper::assert_error_stack_snapshot;
 use test_strategy::proptest;
 
-pub fn raw_base_args(config: &str, db: &str) -> config::RawBaseArgs {
-    config::RawBaseArgs::new(Some(String::from(config)), Some(String::from(db)))
+pub fn raw_base_args(config: &str, db: &str) -> RawBaseArgs {
+    RawBaseArgs::new(Some(String::from(config)), Some(String::from(db)), None)
 }
 
 #[tokio::test]
@@ -37,7 +37,7 @@ async fn validates_args() {
 async fn infers_db_path() {
     std::env::set_var(broker::config::DISABLE_FILE_DISCOVERY_VAR, "1");
 
-    let base = config::RawBaseArgs::new(Some(String::from("testdata/config/basic.yml")), None);
+    let base = RawBaseArgs::new(Some(String::from("testdata/config/basic.yml")), None, None);
     let validated = config::validate_args(base).await;
     let validated = validated.expect("args must have passed validation");
     assert_eq!(
@@ -56,7 +56,7 @@ async fn infers_db_path() {
 async fn infers_db_path_failing_config() {
     std::env::set_var(broker::config::DISABLE_FILE_DISCOVERY_VAR, "1");
 
-    let base = config::RawBaseArgs::new(Some(String::from("")), None);
+    let base = RawBaseArgs::new(Some(String::from("")), None, None);
     let validated = config::validate_args(base.clone()).await;
     let err = validated.expect_err("must have errored");
     assert_error_stack_snapshot!(&base, err);

--- a/tests/it/binary.rs
+++ b/tests/it/binary.rs
@@ -1,0 +1,129 @@
+//! Tests related to the binary itself.
+//!
+//! TODO: test these in Windows as well
+//!       https://www.reddit.com/r/rust/comments/u7q1yx/comment/i5jkiqh/?utm_source=share&utm_medium=web2x&context=3
+
+use std::path::Path;
+
+use tempfile::TempDir;
+
+macro_rules! temp_config {
+    () => {{
+        let tmp = crate::helper::set_temp_data_root();
+        let dir = tmp.path().join("debug");
+        let content = indoc::formatdoc! {r#"
+        fossa_endpoint: https://app.fossa.com
+        fossa_integration_key: abcd1234
+        version: 1
+        debugging:
+          location: {dir:?}
+          retention:
+            days: 1
+        integrations:
+        "#};
+
+        let path = tmp.path().join("config.yml");
+        std::fs::write(&path, content).expect("must write config file");
+
+        println!(
+            "wrote config to {path:?}: {}",
+            std::fs::read_to_string(&path).expect("must read config")
+        );
+        (tmp, path)
+    }};
+}
+
+macro_rules! run {
+    (broker => $($arg:tt)*) => {{
+        let bin = env!("CARGO_BIN_EXE_broker");
+        run!(bin => $($arg)*)
+    }};
+    ($name:expr => $($arg:tt)*) => {{
+        use std::os::unix::process::CommandExt;
+        let command = format!($($arg)*);
+        let root = env!("CARGO_MANIFEST_DIR");
+
+        let args = command.split_ascii_whitespace().collect::<Vec<_>>();
+        std::process::Command::new($name)
+            .args(&args)
+            .current_dir(root)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .process_group(0)
+            .spawn()
+            .expect("must start process")
+    }};
+}
+
+#[track_caller]
+#[cfg(target_family = "unix")]
+fn interrupt(pid: u32) {
+    let output = run!("kill" => "-INT {pid}")
+        .wait_with_output()
+        .expect("must run 'kill'");
+
+    // Just warn so that error messages from broker show up in test failure.
+    if !output.status.success() {
+        eprintln!("[warn] failed to interrupt {pid}: {output:?}")
+    }
+}
+
+#[track_caller]
+#[cfg(target_family = "unix")]
+fn run_and_interrupt_broker(tmp: &TempDir, config_path: &Path) {
+    let config_path = config_path.to_string_lossy().to_string();
+    let data_root = tmp.path().to_string_lossy().to_string();
+    let child = run!(broker => "run -c {config_path} -r {data_root}");
+    let pid = child.id();
+    println!("pid: {pid}");
+
+    // Run Broker.
+    let child = std::thread::spawn(move || child.wait_with_output());
+
+    // Wait a moment for Broker to start, then interrupt it.
+    //
+    // Ideally we'd instead wait for Broker to output some text in its stdout.
+    // This would make things a lot more complicated for seemingly little benefit,
+    // so leave this here unless it becomes flaky or tests start taking way too long.
+    std::thread::sleep(std::time::Duration::from_millis(1000));
+    interrupt(pid);
+
+    // Test the output.
+    let output = child
+        .join()
+        .expect("join child wait thread")
+        .expect("child wasn't running");
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout must have been utf8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr must have been utf8");
+    assert!(
+        stderr.contains("Shut down at due to OS signal"),
+        "ensure interrupted\n- status: {:?}\n- stdout: {stdout}\n- stderr: {stderr}",
+        output.status,
+    );
+}
+
+#[test]
+#[cfg(target_family = "unix")]
+fn interrupts() {
+    let (tmp, config_path) = temp_config!();
+    run_and_interrupt_broker(&tmp, &config_path);
+}
+
+#[test]
+#[cfg(target_family = "unix")]
+fn cleans_up_queue_lock_file() {
+    let (tmp, config_path) = temp_config!();
+
+    // Literally just run it twice.
+    // Ensures that the second time boots instead of failing due to a queue lock file issue.
+    run_and_interrupt_broker(&tmp, &config_path);
+
+    // Wait for the sqlite db to unlock.
+    //
+    // Ideally we'd instead wait for the actual unlock.
+    // This would make things a lot more complicated for seemingly little benefit,
+    // so leave this here unless it becomes flaky or tests start taking way too long.
+    std::thread::sleep(std::time::Duration::from_millis(1000));
+    run_and_interrupt_broker(&tmp, &config_path);
+}

--- a/tests/it/helper.rs
+++ b/tests/it/helper.rs
@@ -14,7 +14,7 @@ pub mod gen;
 #[must_use = "This temporary directory is deleted when this variable is dropped"]
 pub(crate) fn set_temp_data_root() -> TempDir {
     let tmp = tempfile::tempdir().expect("must create temporary directory");
-    std::env::set_var(broker::ext::io::DATA_ROOT_VAR, tmp.path());
+    broker::ext::io::set_data_root(tmp.path()).expect("must set data root");
     tmp
 }
 

--- a/tests/it/queue.rs
+++ b/tests/it/queue.rs
@@ -5,34 +5,32 @@ use broker::queue::{self, Queue, Receiver, Sender};
 async fn racing_senders_err() {
     let _root = set_temp_data_root();
 
-    let _first = Sender::open(Queue::Echo).await.expect("must open first");
-    let err = Sender::open(Queue::Echo)
-        .await
-        .expect_err("must fail to open second");
-    assert_error_stack_snapshot!(&"sender", err);
+    let _first: Sender<Vec<u8>> = Sender::open(Queue::Echo).await.expect("must open first");
+    let second: Result<Sender<Vec<u8>>, _> = Sender::open(Queue::Echo).await;
+    assert_error_stack_snapshot!(&"sender", second.expect_err("must fail to open second"));
 }
 
 #[tokio::test]
 async fn racing_receivers_err() {
     let _root = set_temp_data_root();
 
-    let _first = Receiver::open(Queue::Echo).await.expect("must open first");
-    let err = Receiver::open(Queue::Echo)
-        .await
-        .expect_err("must fail to open second");
-    assert_error_stack_snapshot!(&"receiver", err);
+    let _first: Receiver<Vec<u8>> = Receiver::open(Queue::Echo).await.expect("must open first");
+    let second: Result<Receiver<Vec<u8>>, _> = Receiver::open(Queue::Echo).await;
+    assert_error_stack_snapshot!(&"receiver", second.expect_err("must fail to open second"));
 }
 
 #[tokio::test]
 async fn echo() {
     let _root = set_temp_data_root();
 
-    let (mut tx, mut rx) = queue::open(Queue::Echo).await.expect("must open queue");
+    let (mut tx, mut rx) = queue::open::<String>(Queue::Echo)
+        .await
+        .expect("must open queue");
 
     // Send the messages
     for i in 0..3 {
         let msg = format!("msg {i}");
-        tx.send(msg.as_bytes()).await.expect("must send");
+        tx.send(&msg).await.expect("must send");
         println!("tx {i}: '{msg}'");
     }
     println!("tx: done");
@@ -41,9 +39,9 @@ async fn echo() {
     let mut messages = Vec::new();
     for i in 0..3 {
         let rx = rx.recv().await.expect("must receive");
-        println!("rx {i}: '{}'", String::from_utf8_lossy(rx.data()));
+        let msg = rx.item().expect("must receive message");
+        println!("rx {i}: '{msg}'");
 
-        let msg = String::from_utf8(rx.data().to_vec()).expect("must have parsed message");
         messages.push(msg);
         rx.commit().expect("must commit");
     }

--- a/tests/it/remote_git.rs
+++ b/tests/it/remote_git.rs
@@ -19,6 +19,7 @@ async fn references_on_public_repo_with_no_auth() {
         .expect("no integration loaded from config");
     let references = integration
         .references()
+        .await
         .expect("no results returned from get_references_that_need_scanning on a public repo!");
     let expected_empty_vec: Vec<Reference> = Vec::new();
     assert_eq!(expected_empty_vec, references);
@@ -38,12 +39,11 @@ async fn references_on_private_repo_with_no_auth() {
         .expect("no integration loaded from config");
 
     let context = String::from("references on private repo with bad auth");
-    assert_error_stack_snapshot!(
-        &context,
-        integration.references().expect_err(
-            "no results returned from get_references_that_need_scanning on a private repo"
-        )
-    );
+    let err = integration
+        .references()
+        .await
+        .expect_err("no results returned from get_references_that_need_scanning on a private repo");
+    assert_error_stack_snapshot!(&context, err);
 }
 
 #[tokio::test]
@@ -65,6 +65,7 @@ async fn clone_public_repo_with_no_auth() {
     ));
     integration
         .clone_reference(&reference)
+        .await
         .expect("no path returned from clone_branch_or_tag on a public repo!");
 }
 
@@ -83,10 +84,9 @@ async fn clone_private_repo_with_no_auth() {
         "onetwothree".to_string(),
     ));
     let context = String::from("cloning private repo with bad auth");
-    assert_error_stack_snapshot!(
-        &context,
-        integration
-            .clone_reference(&reference)
-            .expect_err("Could not read from remote repository")
-    );
+    let err = integration
+        .clone_reference(&reference)
+        .await
+        .expect_err("Could not read from remote repository");
+    assert_error_stack_snapshot!(&context, err);
 }

--- a/tests/it/snapshots/it__remote_git__clone_private_repo_with_no_auth.snap
+++ b/tests/it/snapshots/it__remote_git__clone_private_repo_with_no_auth.snap
@@ -1,10 +1,13 @@
 ---
 source: tests/it/remote_git.rs
-expression: "integration.clone_reference(&reference).expect_err(\"Could not read from remote repository\")"
+expression: err
 info: cloning private repo with bad auth
 ---
 run external command
 ├╴at {source location}
+│
+├─▶ IO layer error
+│   ╰╴at {source location}
 │
 ╰─▶ git execution failed
     ├╴at {source location}

--- a/tests/it/snapshots/it__remote_git__references_on_private_repo_with_no_auth.snap
+++ b/tests/it/snapshots/it__remote_git__references_on_private_repo_with_no_auth.snap
@@ -1,10 +1,13 @@
 ---
 source: tests/it/remote_git.rs
-expression: "integration.references().expect_err(\"no results returned from get_references_that_need_scanning on a private repo\")"
+expression: err
 info: references on private repo with bad auth
 ---
 run external command
 ├╴at {source location}
+│
+├─▶ IO layer error
+│   ╰╴at {source location}
 │
 ╰─▶ git execution failed
     ├╴at {source location}


### PR DESCRIPTION
# Overview

Adds git repo polling to the `run` subcommand, and puts new references into the async queue to be processed.

## Acceptance criteria

New references are enqueued for processing.

## Testing plan

This is mostly just gluing together existing functionality, so no new tests.
I did run this in my terminal:
```
; make run
   Compiling broker v0.1.0-pre (/Users/jessica/projects/broker)
    Finished dev [unoptimized + debuginfo] target(s) in 2.69s
     Running `target/debug/broker run`
  2023-03-18T00:01:54.035554Z  INFO broker::debug: Debug artifacts being stored in "/Users/jessica/.config/fossa/broker/debug/trace"
    at src/debug.rs:116

  2023-03-18T00:01:54.045007Z  INFO broker: Loaded Config { fossa_api: Config { endpoint: Endpoint(Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("app.fossa.com")), port: None, path: "/", query: None, fragment: None }), key: Key(ComparableSecret(REDACTED)) }, debug: Config { location: Root("/Users/jessica/.config/fossa/broker/debug"), retention: Retention { days: ArtifactRetentionCount(7) } }, integrations: Integrations([Integration { poll_interval: PollInterval(3600s), protocol: Git(Http { endpoint: Remote("https://github.com/fossas/fossa-cli.git"), auth: None }) }]) }
    at src/main.rs:136

  2023-03-18T00:02:05.249746Z  INFO broker::subcommand::run: Enqueued task to scan using git protocol with transport cloning via HTTP from https://github.com/fossas/fossa-cli.git with no authentication at git branch 'ANE-891-dynamic-go-tactic' with head commit 'af759ce81175b748cb8f1f2f8899baf6e1677d71'
    at src/subcommand/run.rs:244
    in broker::subcommand::run::do_poll_integration
    in broker::subcommand::run::do_poll_integrations
    in broker::subcommand::run::main

... some more tasks ...

  2023-03-18T00:02:05.250517Z  INFO broker::subcommand::run: Next poll interval for using git protocol with transport cloning via HTTP from https://github.com/fossas/fossa-cli.git with no authentication in 3600s
    at src/subcommand/run.rs:263
    in broker::subcommand::run::do_poll_integration
    in broker::subcommand::run::do_poll_integrations
    in broker::subcommand::run::main

  2023-03-18T00:02:05.250790Z  INFO broker::subcommand::run: Pretending to scan using git protocol with transport cloning via HTTP from https://github.com/fossas/fossa-cli.git with no authentication at git branch 'ANE-891-dynamic-go-tactic' with head commit 'af759ce81175b748cb8f1f2f8899baf6e1677d71'
    at src/subcommand/run.rs:284
    in broker::subcommand::run::do_scan_git_reference with job: ScanGitVCSReference { scan_id: "356877f4-7d21-4803-8623-549466292f19", integration: Integration { poll_interval: PollInterval(3600s), protocol: Git(Http { endpoint: Remote("https://github.com/fossas/fossa-cli.git"), auth: None }) }, reference: Git(Branch { name: "ANE-891-dynamic-go-tactic", head: "af759ce81175b748cb8f1f2f8899baf6e1677d71" }) }, scan_id: "356877f4-7d21-4803-8623-549466292f19"
    in broker::subcommand::run::do_scan_git_references
    in broker::subcommand::run::main

... some more tasks ...
```

This did expose some issues:
- ctrl+c leaves the task queues in an "open" state, forcing manual deletion of their lockfiles.
- I can't get it to clone SSH repos, this may be a bug in the git library.
- The code to keep this functionality generalized is starting to spaghettify pretty badly, if I get time I may take a redesign pass on how we organize our types & modules
- The wording in these info messages is _really_ verbose, I'll probably take a pass at displaying these in a more useful way to the user.
- Working with async for this problem is a bit on the complicated side, I think it may be more worthwhile to use plain old threads, but I stuck with async for this PR as that's what we've done so far.

I want to keep this PR on the smaller side, so I'd like to merge despite these issues and address them in future PRs.

## References

Implements https://fossa.atlassian.net/browse/ANE-837

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
