### PR TITLE
Only http remotes should be required to start with http

### DIFF
--- a/src/api/remote/git/repository.rs
+++ b/src/api/remote/git/repository.rs
@@ -280,10 +280,9 @@ fn blobless_clone(
 
 #[tracing::instrument(skip(transport))]
 fn default_args(transport: &Transport) -> Result<Vec<String>, Report<Error>> {
-    ensure!(
-        transport.endpoint().starts_with("http"),
-        Error::HttpRemoteInvalid,
-    );
+    if let Transport::Http { endpoint, .. } = transport {
+        ensure!(endpoint.starts_with("http"), Error::HttpRemoteInvalid,);
+    }
 
     let header_args = match transport.auth() {
         // git -c credential-helper="" -c http.extraHeader="AUTHORIZATION: Basic ${B64_GITHUB_TOKEN}" clone https://github.com/spatten/fanopticon


### PR DESCRIPTION
# Overview

We are validating that remotes must start with `http`, but this is not true for ssh remotes.

This PR just fixes that to only run the validation for `http` remotes.

## Acceptance criteria

You should be able to use a remote like `git@github.com...`

## Testing plan

Put this integration in your config.yml (you'll have to change the path to the ssh key file):

```yaml
integrations:
  - type: git
    poll_interval: 1h
    # remote: https://github.com/fossas/FOSSA.git
    remote: git@github.com:fossas/FOSSA.git
    auth:
      type: ssh_key_file
      path: "/Users/scott/.ssh/id_ed25519"
```

This will clone the first integration in your config file. It should work with an ssh remote:

```
cargo run -- clone`
```

Then try with a valid and invalid http remote to check that the validation is still working for http remotes:

Valid:

```yaml
  - type: git
    poll_interval: 1h
    remote: https://github.com/fossas/broker.git
    auth:
      type: http_basic
      username: "pat"
      password: "Github access token"
```

Invalid:

```yaml
  - type: git
    poll_interval: 1h
    remote: git@github.com/fossas/broker.git
    auth:
      type: http_basic
      username: "pat"
      password: "Github access token"
```

Valid:

```
cargo run -- clone
   Compiling broker v0.1.0-pre (/Users/scott/fossa/broker)
    Finished dev [unoptimized + debuginfo] target(s) in 1.87s
     Running `target/debug/broker clone`
  2023-03-20T20:02:35.265397Z  INFO broker::debug: Debug artifacts being stored in "/Users/scott/.config/fossa/broker/debugging/trace"
    at src/debug.rs:116

~/fossa/broker  git:(fix-remote-validation-for-ssh-remotes) 4≡
# echo $?
0
```

invalid:

```
 cargo run -- clone
   Compiling broker v0.1.0-pre (/Users/scott/fossa/broker)
    Finished dev [unoptimized + debuginfo] target(s) in 1.55s
     Running `target/debug/broker clone`
  2023-03-20T20:01:24.926903Z  INFO broker::debug: Debug artifacts being stored in "/Users/scott/.config/fossa/broker/debugging/trace"
    at src/debug.rs:116

Error: a fatal error occurred at runtime
├╴at src/main.rs:163:10
├╴help: try running Broker with the '--help' argument to see available options and usage suggestions
├╴support: if you believe this to be a defect, please report a bug to FOSSA support at https://support.fossa.com
├╴context: broker version: 0.1.0-pre
│
├─▶ run external command
│   ╰╴at src/api/remote/git/transport.rs:82:43
│
╰─▶ http remote does not begin with 'http'
    ╰╴at src/api/remote/git/repository.rs:284:9
```

It's hard to add tests for ssh auth without a github account with a valid ssh key that we can check into the repo. So I'm going to leave this untested for now.

## Risks

## References

## Checklist


- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
