### PR TITLE
Fixes for queue and other small stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ name = "broker"
 version = "0.1.0-pre"
 dependencies = [
  "async-trait",
+ "atty",
  "automod",
  "base64",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ automod = "1.0.8"
 tokio-retry = "0.3.0"
 bincode = "1.3.3"
 uuid = { version = "1.3.0", features = ["v4"] }
+atty = "0.2.14"
 
 [dev-dependencies]
 insta = { version = "1.28.0", features = ["filters", "json", "yaml"] }

--- a/src/api/remote/git/transport.rs
+++ b/src/api/remote/git/transport.rs
@@ -103,7 +103,7 @@ impl RemoteProvider for Transport {
         // The cost is irrelevant next to the IO time.
         let transport = self.to_owned();
         let reference = reference.to_owned();
-        io::spawn_blocking_stacked(move || repository::clone_reference(&transport, &reference))
+        io::spawn_blocking(move || repository::clone_reference(&transport, &reference))
             .await
             .change_context(RemoteProviderError::RunCommand)
     }
@@ -114,7 +114,7 @@ impl RemoteProvider for Transport {
         // Rather than get into tracking lifetimes, just clone it.
         // The cost is irrelevant next to the IO time.
         let transport = self.to_owned();
-        io::spawn_blocking_stacked(move || repository::list_references(&transport))
+        io::spawn_blocking(move || repository::list_references(&transport))
             .await
             .change_context(RemoteProviderError::RunCommand)
     }

--- a/src/download_fossa_cli.rs
+++ b/src/download_fossa_cli.rs
@@ -69,7 +69,7 @@ pub async fn ensure_fossa_cli() -> Result<PathBuf, Error> {
     };
 
     // if it is not in either location, then download it
-    download(&data_root)
+    download(data_root)
         .await
         .describe("fossa-cli not found in your path, attempting to download it")
 }

--- a/src/ext/io.rs
+++ b/src/ext/io.rs
@@ -31,7 +31,7 @@ use tokio::task;
 use crate::ext::error_stack::{DescribeContext, ErrorHelper, IntoContext};
 
 pub mod sync;
-pub use sync::DATA_ROOT_VAR;
+pub use sync::set_data_root;
 
 /// Errors that are possibly surfaced during IO actions.
 #[derive(Debug, thiserror::Error)]
@@ -53,7 +53,7 @@ pub enum Error {
 ///
 /// Users may also customize this root via the [`DATA_ROOT_VAR`] environment variable.
 #[tracing::instrument]
-pub async fn data_root() -> Result<PathBuf, Report<Error>> {
+pub async fn data_root() -> Result<&'static PathBuf, Report<Error>> {
     run_background(sync::data_root).await
 }
 

--- a/src/ext/io.rs
+++ b/src/ext/io.rs
@@ -134,23 +134,24 @@ where
         .change_context(Error::IO)
 }
 
-/// Run the provided blocking closure in the background,
-/// wrapping any error returned in this module's `Error::IO` context.
+/// Run the provided blocking closure in the background.
+///
+/// The error returned by the function is wrapped inside a report
+/// and set to this module's `Error::IO` context.
 #[tracing::instrument(skip_all)]
-pub async fn spawn_blocking<T, E, F>(work: F) -> Result<T, Report<Error>>
+pub async fn spawn_blocking_wrap<T, E, F>(work: F) -> Result<T, Report<Error>>
 where
     T: Send + 'static,
     E: std::error::Error + Sync + Send + 'static,
     Report<E>: From<E>,
     F: FnOnce() -> Result<T, E> + Send + 'static,
 {
-    spawn_blocking_stacked(|| work().into_report()).await
+    spawn_blocking(|| work().into_report()).await
 }
 
-/// Run the provided blocking closure in the background,
-/// wrapping any error returned in this module's `Error::IO` context.
+/// Run the provided blocking closure in the background.
 #[tracing::instrument(skip_all)]
-pub async fn spawn_blocking_stacked<T, E, F>(work: F) -> Result<T, Report<Error>>
+pub async fn spawn_blocking<T, E, F>(work: F) -> Result<T, Report<Error>>
 where
     T: Send + 'static,
     E: Context,

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -129,7 +129,7 @@ where
 
     async fn open_internal(path: PathBuf) -> Result<Self, Report<Error>> {
         let lock_path = path.join("send.lock");
-        io::spawn_blocking(move || yaque::Sender::open(path))
+        io::spawn_blocking_wrap(move || yaque::Sender::open(path))
             .await
             .change_context(Error::Open)
             .help(indoc! {"
@@ -210,7 +210,7 @@ where
 
     async fn open_internal(path: PathBuf) -> Result<Self, Report<Error>> {
         let lock_path = path.join("recv.lock");
-        io::spawn_blocking(move || yaque::Receiver::open(path))
+        io::spawn_blocking_wrap(move || yaque::Receiver::open(path))
             .await
             .change_context(Error::Open)
             .help(indoc! {"

--- a/tests/it/args.rs
+++ b/tests/it/args.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use broker::{
     api::fossa::{Endpoint, Key},
-    config,
+    config::{self, RawBaseArgs},
 };
 use proptest::{prop_assert, prop_assert_eq};
 use url::Url;
@@ -10,8 +10,8 @@ use url::Url;
 use crate::helper::assert_error_stack_snapshot;
 use test_strategy::proptest;
 
-pub fn raw_base_args(config: &str, db: &str) -> config::RawBaseArgs {
-    config::RawBaseArgs::new(Some(String::from(config)), Some(String::from(db)))
+pub fn raw_base_args(config: &str, db: &str) -> RawBaseArgs {
+    RawBaseArgs::new(Some(String::from(config)), Some(String::from(db)), None)
 }
 
 #[tokio::test]
@@ -37,7 +37,7 @@ async fn validates_args() {
 async fn infers_db_path() {
     std::env::set_var(broker::config::DISABLE_FILE_DISCOVERY_VAR, "1");
 
-    let base = config::RawBaseArgs::new(Some(String::from("testdata/config/basic.yml")), None);
+    let base = RawBaseArgs::new(Some(String::from("testdata/config/basic.yml")), None, None);
     let validated = config::validate_args(base).await;
     let validated = validated.expect("args must have passed validation");
     assert_eq!(
@@ -56,7 +56,7 @@ async fn infers_db_path() {
 async fn infers_db_path_failing_config() {
     std::env::set_var(broker::config::DISABLE_FILE_DISCOVERY_VAR, "1");
 
-    let base = config::RawBaseArgs::new(Some(String::from("")), None);
+    let base = RawBaseArgs::new(Some(String::from("")), None, None);
     let validated = config::validate_args(base.clone()).await;
     let err = validated.expect_err("must have errored");
     assert_error_stack_snapshot!(&base, err);

--- a/tests/it/binary.rs
+++ b/tests/it/binary.rs
@@ -1,0 +1,129 @@
+//! Tests related to the binary itself.
+//!
+//! TODO: test these in Windows as well
+//!       https://www.reddit.com/r/rust/comments/u7q1yx/comment/i5jkiqh/?utm_source=share&utm_medium=web2x&context=3
+
+use std::path::Path;
+
+use tempfile::TempDir;
+
+macro_rules! temp_config {
+    () => {{
+        let tmp = crate::helper::set_temp_data_root();
+        let dir = tmp.path().join("debug");
+        let content = indoc::formatdoc! {r#"
+        fossa_endpoint: https://app.fossa.com
+        fossa_integration_key: abcd1234
+        version: 1
+        debugging:
+          location: {dir:?}
+          retention:
+            days: 1
+        integrations:
+        "#};
+
+        let path = tmp.path().join("config.yml");
+        std::fs::write(&path, content).expect("must write config file");
+
+        println!(
+            "wrote config to {path:?}: {}",
+            std::fs::read_to_string(&path).expect("must read config")
+        );
+        (tmp, path)
+    }};
+}
+
+macro_rules! run {
+    (broker => $($arg:tt)*) => {{
+        let bin = env!("CARGO_BIN_EXE_broker");
+        run!(bin => $($arg)*)
+    }};
+    ($name:expr => $($arg:tt)*) => {{
+        use std::os::unix::process::CommandExt;
+        let command = format!($($arg)*);
+        let root = env!("CARGO_MANIFEST_DIR");
+
+        let args = command.split_ascii_whitespace().collect::<Vec<_>>();
+        std::process::Command::new($name)
+            .args(&args)
+            .current_dir(root)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .process_group(0)
+            .spawn()
+            .expect("must start process")
+    }};
+}
+
+#[track_caller]
+#[cfg(target_family = "unix")]
+fn interrupt(pid: u32) {
+    let output = run!("kill" => "-INT {pid}")
+        .wait_with_output()
+        .expect("must run 'kill'");
+
+    // Just warn so that error messages from broker show up in test failure.
+    if !output.status.success() {
+        eprintln!("[warn] failed to interrupt {pid}: {output:?}")
+    }
+}
+
+#[track_caller]
+#[cfg(target_family = "unix")]
+fn run_and_interrupt_broker(tmp: &TempDir, config_path: &Path) {
+    let config_path = config_path.to_string_lossy().to_string();
+    let data_root = tmp.path().to_string_lossy().to_string();
+    let child = run!(broker => "run -c {config_path} -r {data_root}");
+    let pid = child.id();
+    println!("pid: {pid}");
+
+    // Run Broker.
+    let child = std::thread::spawn(move || child.wait_with_output());
+
+    // Wait a moment for Broker to start, then interrupt it.
+    //
+    // Ideally we'd instead wait for Broker to output some text in its stdout.
+    // This would make things a lot more complicated for seemingly little benefit,
+    // so leave this here unless it becomes flaky or tests start taking way too long.
+    std::thread::sleep(std::time::Duration::from_millis(1000));
+    interrupt(pid);
+
+    // Test the output.
+    let output = child
+        .join()
+        .expect("join child wait thread")
+        .expect("child wasn't running");
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout must have been utf8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr must have been utf8");
+    assert!(
+        stderr.contains("Shut down at due to OS signal"),
+        "ensure interrupted\n- status: {:?}\n- stdout: {stdout}\n- stderr: {stderr}",
+        output.status,
+    );
+}
+
+#[test]
+#[cfg(target_family = "unix")]
+fn interrupts() {
+    let (tmp, config_path) = temp_config!();
+    run_and_interrupt_broker(&tmp, &config_path);
+}
+
+#[test]
+#[cfg(target_family = "unix")]
+fn cleans_up_queue_lock_file() {
+    let (tmp, config_path) = temp_config!();
+
+    // Literally just run it twice.
+    // Ensures that the second time boots instead of failing due to a queue lock file issue.
+    run_and_interrupt_broker(&tmp, &config_path);
+
+    // Wait for the sqlite db to unlock.
+    //
+    // Ideally we'd instead wait for the actual unlock.
+    // This would make things a lot more complicated for seemingly little benefit,
+    // so leave this here unless it becomes flaky or tests start taking way too long.
+    std::thread::sleep(std::time::Duration::from_millis(1000));
+    run_and_interrupt_broker(&tmp, &config_path);
+}

--- a/tests/it/helper.rs
+++ b/tests/it/helper.rs
@@ -14,7 +14,7 @@ pub mod gen;
 #[must_use = "This temporary directory is deleted when this variable is dropped"]
 pub(crate) fn set_temp_data_root() -> TempDir {
     let tmp = tempfile::tempdir().expect("must create temporary directory");
-    std::env::set_var(broker::ext::io::DATA_ROOT_VAR, tmp.path());
+    broker::ext::io::set_data_root(tmp.path()).expect("must set data root");
     tmp
 }
 

--- a/tests/it/queue.rs
+++ b/tests/it/queue.rs
@@ -5,34 +5,32 @@ use broker::queue::{self, Queue, Receiver, Sender};
 async fn racing_senders_err() {
     let _root = set_temp_data_root();
 
-    let _first = Sender::open(Queue::Echo).await.expect("must open first");
-    let err = Sender::open(Queue::Echo)
-        .await
-        .expect_err("must fail to open second");
-    assert_error_stack_snapshot!(&"sender", err);
+    let _first: Sender<Vec<u8>> = Sender::open(Queue::Echo).await.expect("must open first");
+    let second: Result<Sender<Vec<u8>>, _> = Sender::open(Queue::Echo).await;
+    assert_error_stack_snapshot!(&"sender", second.expect_err("must fail to open second"));
 }
 
 #[tokio::test]
 async fn racing_receivers_err() {
     let _root = set_temp_data_root();
 
-    let _first = Receiver::open(Queue::Echo).await.expect("must open first");
-    let err = Receiver::open(Queue::Echo)
-        .await
-        .expect_err("must fail to open second");
-    assert_error_stack_snapshot!(&"receiver", err);
+    let _first: Receiver<Vec<u8>> = Receiver::open(Queue::Echo).await.expect("must open first");
+    let second: Result<Receiver<Vec<u8>>, _> = Receiver::open(Queue::Echo).await;
+    assert_error_stack_snapshot!(&"receiver", second.expect_err("must fail to open second"));
 }
 
 #[tokio::test]
 async fn echo() {
     let _root = set_temp_data_root();
 
-    let (mut tx, mut rx) = queue::open(Queue::Echo).await.expect("must open queue");
+    let (mut tx, mut rx) = queue::open::<String>(Queue::Echo)
+        .await
+        .expect("must open queue");
 
     // Send the messages
     for i in 0..3 {
         let msg = format!("msg {i}");
-        tx.send(msg.as_bytes()).await.expect("must send");
+        tx.send(&msg).await.expect("must send");
         println!("tx {i}: '{msg}'");
     }
     println!("tx: done");
@@ -41,9 +39,9 @@ async fn echo() {
     let mut messages = Vec::new();
     for i in 0..3 {
         let rx = rx.recv().await.expect("must receive");
-        println!("rx {i}: '{}'", String::from_utf8_lossy(rx.data()));
+        let msg = rx.item().expect("must receive message");
+        println!("rx {i}: '{msg}'");
 
-        let msg = String::from_utf8(rx.data().to_vec()).expect("must have parsed message");
         messages.push(msg);
         rx.commit().expect("must commit");
     }


### PR DESCRIPTION
# Overview

- Makes queues typed.
  - For example instead of accepting `Receiver`, one now accepts `Receiver<T>`, where `T` is the type being sent through the queue.
  - The queue implementations now handle serialization transparently.
- Queues now shut down and clean up their lockfiles on ctrl+c.
- Refactored some customization that was based on environment variables, since these are hard to control during tests.

## Testing plan

Relied on automated testing.

## References

Mostly based on issues observed in #18 and #20.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
