### PR TITLE
unset the GIT_ASKPASS env variable when running git

### DIFF
--- a/src/api/remote/git/repository.rs
+++ b/src/api/remote/git/repository.rs
@@ -131,7 +131,10 @@ where
     let env = env_vars(transport, &mut ssh_key_file)?;
 
     let mut command = Command::new("git");
-    command.args(full_args.clone()).envs(env);
+    command
+        .args(full_args.clone())
+        .envs(env)
+        .env_remove("GIT_ASKPASS");
     if let Some(directory) = cwd {
         command.current_dir(directory);
     }


### PR DESCRIPTION
# Overview

When running `make test` in a vs code terminal, we get slightly different output when trying to run the git tests.

To fix this, we need to unset the `GIT_ASKPASS` variable.

I think we should do this in code, rather than in the Makefile, as this makes sure we never try to run `GIT_ASKPASS` if you run broker in a vs code terminal

## Acceptance criteria

The tests should pass in vs code

## Testing plan


```
make nextest run
```

## Risks


## References



## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
