### PR TITLE
Broker fix

### DIFF
--- a/src/api/remote/git/repository.rs
+++ b/src/api/remote/git/repository.rs
@@ -89,9 +89,7 @@ pub async fn clone_reference(
 }
 
 /// The args for the call to ls-remote
-///
-/// This is public because it is used in the fix subcommand
-pub fn ls_remote_args(transport: &Transport) -> Vec<Value> {
+fn ls_remote_args(transport: &Transport) -> Vec<Value> {
     vec![
         Value::new_plain("ls-remote"),
         Value::new_plain("--quiet"),
@@ -123,7 +121,7 @@ async fn get_all_references(transport: &Transport) -> Result<Vec<Reference>, Rep
 
 /// Construct a git command, including the default args and the environment required for the transport's auth
 #[tracing::instrument(skip(transport))]
-pub fn construct_git_command(
+fn construct_git_command(
     transport: &Transport,
     args: &[Value],
     cwd: Option<&Path>,
@@ -165,6 +163,23 @@ async fn run_git(
     }
 
     Ok(output)
+}
+
+/// Construct a pastable string containing a git command, including the default args and the environment required for the transport's auth
+#[tracing::instrument(skip(transport))]
+fn pastable_git_command(
+    transport: &Transport,
+    args: &[Value],
+    cwd: Option<&Path>,
+) -> Result<String, Report<Error>> {
+    let command = construct_git_command(transport, args, cwd)?;
+    command.describe().pastable().wrap_ok()
+}
+
+/// Construct a pastable string containing a `git ls-remote` command, including the default args and the environment required for the transport's auth
+pub fn pastable_ls_remote_command(transport: &Transport) -> Result<String, Report<Error>> {
+    let command = construct_git_command(transport, &ls_remote_args(transport), None)?;
+    command.describe().pastable().wrap_ok()
 }
 
 // Days until a commit is considered stale and will not be scanned

--- a/src/api/remote/git/repository.rs
+++ b/src/api/remote/git/repository.rs
@@ -178,8 +178,7 @@ fn pastable_git_command(
 
 /// Construct a pastable string containing a `git ls-remote` command, including the default args and the environment required for the transport's auth
 pub fn pastable_ls_remote_command(transport: &Transport) -> Result<String, Report<Error>> {
-    let command = construct_git_command(transport, &ls_remote_args(transport), None)?;
-    command.describe().pastable().wrap_ok()
+    pastable_git_command(transport, &ls_remote_args(transport), None)
 }
 
 // Days until a commit is considered stale and will not be scanned

--- a/src/api/remote/git/repository.rs
+++ b/src/api/remote/git/repository.rs
@@ -106,9 +106,9 @@ pub fn clone_reference(
     Ok(tmpdir)
 }
 
-#[tracing::instrument(skip(transport))]
-fn get_all_references(transport: &Transport) -> Result<Vec<Reference>, Report<Error>> {
-    // run `git ls-remote --quiet <endpoint>` to get a list of references
+/// run `git ls-remote --quiet <endpoint>` to get a list of references
+#[tracing::instrument]
+pub fn ls_remote(transport: &Transport) -> Result<String, Report<Error>> {
     let output = run_git(
         transport,
         &[
@@ -119,6 +119,12 @@ fn get_all_references(transport: &Transport) -> Result<Vec<Reference>, Report<Er
         None,
     )?;
     let output = String::from_utf8(output.stdout).context(Error::ParseGitOutput)?;
+    Ok(output)
+}
+
+#[tracing::instrument(skip(transport))]
+fn get_all_references(transport: &Transport) -> Result<Vec<Reference>, Report<Error>> {
+    let output = ls_remote(transport)?;
     let references = parse_ls_remote(output)?;
 
     // Tags sometimes get duplicated in the output from `git ls-remote`, like this:

--- a/src/api/remote/git/repository.rs
+++ b/src/api/remote/git/repository.rs
@@ -89,7 +89,7 @@ pub async fn clone_reference(
 }
 
 /// ls_remote calls `git ls-remote <endpoint>` on the transport's endpoint
-#[tracing::instrumnet(skip(transport))]
+#[tracing::instrument(skip(transport))]
 pub async fn ls_remote(transport: &Transport) -> Result<String, Report<Error>> {
     let output = run_git(
         transport,

--- a/src/ext/command.rs
+++ b/src/ext/command.rs
@@ -291,7 +291,7 @@ impl OutputProvider for Output {
 /// Use `wait` to wait for the process to close.
 ///
 /// # Secrets
-///  
+///
 /// The caller is responsible for ensuring that the output is redacted,
 /// if this output is to be printed.
 /// Use the [`redact_str`] or [`redact_bytes`] methods on this struct
@@ -639,6 +639,20 @@ impl Description {
             .join(", ");
         format!("[{}]", joined)
     }
+
+    /// Provides a representation of the command that can be pasted into the terminal
+    pub fn pastable(&self) -> String {
+        let envs = self
+            .envs
+            .clone()
+            .into_iter()
+            .filter(|e| !e.contains("<REMOVED>"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let args = self.args.join(" ");
+        let name = &self.name;
+        format!("{envs} {name} {args}")
+    }
 }
 
 /// Supports rendering a command in the Broker standardized form.
@@ -661,7 +675,7 @@ impl CommandDescriber for Command {
             .envs
             .iter()
             .map(|(key, value)| match value {
-                Some(value) => format!("{key}={value}"),
+                Some(value) => format!("{key}='{value}'"),
                 None => format!("{key}=<REMOVED>"),
             })
             .collect_vec();

--- a/src/ext/command.rs
+++ b/src/ext/command.rs
@@ -18,6 +18,7 @@ use crate::ext::secrecy::REDACTION_LITERAL;
 
 use super::{result::WrapOk, secrecy::ComparableSecretString};
 
+const REMOVED_LITERAL: &str = "<REMOVED>";
 /// Any error encountered running the program.
 #[derive(Debug, Error)]
 pub enum Error {
@@ -646,7 +647,7 @@ impl Description {
             .envs
             .clone()
             .into_iter()
-            .filter(|e| !e.contains("<REMOVED>"))
+            .map(|e| e.replace(REMOVED_LITERAL, "''"))
             .collect::<Vec<_>>()
             .join(" ");
         let args = self.args.join(" ");
@@ -676,7 +677,7 @@ impl CommandDescriber for Command {
             .iter()
             .map(|(key, value)| match value {
                 Some(value) => format!("{key}='{value}'"),
-                None => format!("{key}=<REMOVED>"),
+                None => format!("{key}={REMOVED_LITERAL}"),
             })
             .collect_vec();
 
@@ -696,7 +697,7 @@ impl CommandDescriber for std::process::Command {
             .map(|(key, value)| (key.to_string_lossy(), value.map(OsStr::to_string_lossy)))
             .map(|(key, value)| match value {
                 Some(value) => format!("{key}={value}"),
-                None => format!("{key}=<REMOVED>"),
+                None => format!("{key}={REMOVED_LITERAL}"),
             })
             .collect_vec();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use broker::{
     ext::error_stack::{DescribeContext, ErrorDocReference, FatalErrorReport},
 };
 use clap::{Parser, Subcommand};
-use error_stack::{bail, fmt::ColorMode, Report, Result, ResultExt};
+use error_stack::{fmt::ColorMode, Report, Result, ResultExt};
 use tap::TapFallible;
 use tracing::debug;
 
@@ -24,9 +24,6 @@ use tracing::debug;
 enum Error {
     #[error("determine effective configuration")]
     DetermineEffectiveConfig,
-
-    #[error("this subcommand is not implemented")]
-    SubcommandUnimplemented,
 
     #[error("a fatal error occurred during internal configuration")]
     InternalSetup,

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,7 @@ async fn main_fix(args: config::RawRunArgs) -> Result<(), Error> {
         .run_tracing_sink()
         .change_context(Error::InternalSetup)?;
 
-    broker::subcommand::fix::main(conf)
+    broker::subcommand::fix::main(&conf)
         .await
         .change_context(Error::Runtime)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,7 @@ async fn main_fix(args: config::RawRunArgs) -> Result<(), Error> {
         .run_tracing_sink()
         .change_context(Error::InternalSetup)?;
 
-    broker::subcommand::fix::main(args.context(), conf)
+    broker::subcommand::fix::main(conf)
         .await
         .change_context(Error::Runtime)
 }

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,4 +1,5 @@
 //! Implementations for the subcommands.
 
+pub mod fix;
 pub mod init;
 pub mod run;

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -10,7 +10,10 @@ use crate::{
     api::{
         http,
         remote::{
-            git::{repository, transport},
+            git::{
+                repository,
+                transport::{self, Transport},
+            },
             Integration, Protocol, Remote,
         },
         ssh,
@@ -49,6 +52,148 @@ pub enum Error {
         /// The path on Fossa
         path: String,
     },
+}
+
+impl Error {
+    fn fix_explanation(&self) -> String {
+        match self {
+            Error::CheckIntegration { remote, msg, .. } => {
+                format!("❌ {}\n\n{}", remote.to_string().red(), msg)
+            }
+            Error::CheckFossaGet { msg } => {
+                format!("❌ {} {}", "Error checking connection to FOSSA:".red(), msg)
+            }
+            Error::CreateFullFossaUrl { remote, path } => {
+                format!(
+                    "❌ Creating a full URL from your remote of {} and path = {}",
+                    remote, path
+                )
+            }
+        }
+    }
+
+    fn integration_error(
+        remote: &Remote,
+        transport: &Transport,
+        err: Report<repository::Error>,
+    ) -> Self {
+        let msg = formatdoc!(
+            "
+        We encountered an error while trying to connect to your git remote at {}.\n\n{}\n\nFull error message from git:\n\n{}\n\n",
+            remote,
+            Self::protocol_connection_explanation(transport),
+            err.to_string(),
+        );
+        Error::CheckIntegration {
+            remote: remote.clone(),
+            error: err.to_string(),
+            msg,
+        }
+    }
+
+    fn protocol_connection_explanation(transport: &transport::Transport) -> String {
+        let shared_instructions = "We were unable to connect to this repository. Please make sure that the authentication info and the remote are set correctly in your config.yml file.";
+        let base64_command = r#"echo -n "<username>:<password>" | base64"#;
+        let specific_instructions = match transport {
+            transport::Transport::Ssh {
+                auth: ssh::Auth::KeyFile(key_path),
+                endpoint,
+            } => {
+                let key_path = key_path.to_string_lossy();
+                let command = format!(
+                r#"GIT_SSH_COMMAND="ssh -i {} -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -F /dev/null" git ls-remote {}"#,
+                key_path, endpoint
+            ).green();
+                formatdoc!(
+                "You are using SSH keyfile authentication for this remote. This connects to your repository by setting the `GIT_SSH_COMMAND` environment variable with the path to the ssh key that you provided in your config file. Please make sure you can run the following command to verify the connection:
+
+                {}", command
+            )
+            }
+            transport::Transport::Ssh {
+                auth: ssh::Auth::KeyValue(_),
+                endpoint,
+            } => {
+                let command = format!(
+                r#"GIT_SSH_COMMAND="ssh -i <path with ssh key> -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -F /dev/null" git ls-remote {}"#,
+                endpoint
+            ).green();
+                formatdoc!(
+                "You are using SSH key authentication for this remote. This method of authentication writes the SSH key that you provided in your config file to a temporary file, and then connects to your repository by setting the `GIT_SSH_COMMAND` environment variable with the path to the temporary file. To debug this, please write the ssh key to a file and then make sure you can run the following command to verify the connection.
+
+                The path with the ssh key in it must have permissions of 0x660 on Linux and MacOS.
+
+                {}", command
+            )
+            }
+            transport::Transport::Http {
+                auth: Some(http::Auth::Basic { .. }),
+                endpoint,
+            } => {
+                let command = format!(
+                r#"git -c "http.extraHeader=Authorization: Basic <base64 encoded username and password>" {}"#,
+                endpoint
+            )
+            .green();
+
+                formatdoc!(
+                    r#"You are using HTTP basic authentication for this remote. This method of authentication encodes the username and password as a base64 string and then passes that to git using the "http.extraHeader" parameter. To debug this, please make sure that the following commands work.
+
+                You generate the base64 encoded username and password by joining them with a ":" and then base64 encoding them. If your username was "pat" and your password was "password123", then you would base64 encode "pat:password123". For example, you can use a command like this:
+
+                {}
+
+                Once you have the base64 encoded username and password, use them in a command like this:
+
+                {}"#,
+                    base64_command,
+                    command
+                )
+            }
+            transport::Transport::Http {
+                auth: Some(http::Auth::Header { .. }),
+                endpoint,
+            } => {
+                let command = format!(
+                    r#"git -c "http.extraHeader=<your header>" ls-remote {}"#,
+                    endpoint
+                )
+                .green();
+                formatdoc!(
+                    r#"You are using HTTP header authentication for this remote. This method of authentication passes the header that you have provided in your config file to git using the "http.extraHeader" parameter. To debug this, please make sure the following command works, making sure to substitute the header from your config file into the right spot:
+
+                {}
+
+                You generate the header by making a string that looks like this:
+
+                Authorization: Basic <base64 encoded username:password>
+
+                If your username was "pat" and your password was "password123", then you would base64 encode "pat:password123". For example, you can use a command like this:
+
+                {}
+
+                The username you use depends on the git hosting platform you are authenticating to. For details on this, please see the `config.example.yml` file in your broker config directory. You can re-generate this file at any time by running `broker init`.
+                "#,
+                    command,
+                    base64_command
+                )
+            }
+            transport::Transport::Http {
+                auth: None,
+                endpoint,
+            } => {
+                let command = format!("git ls-remote {}", endpoint).green();
+                formatdoc!(
+                    r#"You are using http transport with no authentication for this integration. To debug this, please make sure that the following command works:
+
+                {}"#,
+                    command
+                )
+            }
+        };
+
+        format!("{}\n\n{}", shared_instructions, specific_instructions)
+    }
 }
 
 /// Similar to [`AppContext`], but scoped for this subcommand.
@@ -93,20 +238,7 @@ fn print_errors(msg: String, errors: Vec<Error>) {
     if !errors.is_empty() {
         println!("\n{}\n", msg,);
         for err in errors {
-            match err {
-                Error::CheckIntegration { remote, msg, .. } => {
-                    println!("❌ {}\n\n{}", remote.to_string().red(), msg);
-                }
-                Error::CheckFossaGet { msg } => {
-                    println!("❌ {} {}", "Error checking connection to FOSSA:".red(), msg);
-                }
-                Error::CreateFullFossaUrl { remote, path } => {
-                    println!(
-                        "❌ Creating a full URL from your remote of {} and path = {}",
-                        remote, path
-                    )
-                }
-            }
+            println!("{}", err.fix_explanation());
         }
     }
 }
@@ -140,127 +272,9 @@ async fn check_integrations(ctx: &CmdContext) -> Vec<Error> {
 #[tracing::instrument]
 async fn check_integration(integration: &Integration) -> Result<(), Error> {
     let Protocol::Git(transport) = integration.protocol();
-    repository::ls_remote(transport).or_else(|err| {
-        let remote = integration.remote().clone();
-        let msg = formatdoc!(
-            "
-        We encountered an error while trying to connect to your git remote at {}.\n\n{}\n\nFull error message from git:\n\n{}\n\n",
-            remote,
-            protocol_connection_explanation(transport),
-            err.to_string(),
-        );
-        Error::CheckIntegration {
-            remote,
-            error: err.to_string(),
-            msg,
-        }
-        .wrap_err()
-    })?;
+    repository::ls_remote(transport)
+        .or_else(|err| Error::integration_error(integration.remote(), transport, err).wrap_err())?;
     Ok(())
-}
-
-fn protocol_connection_explanation(transport: &transport::Transport) -> String {
-    let shared_instructions = "We were unable to connect to this repository. Please make sure that the authentication info and the remote are set correctly in your config.yml file.";
-    let base64_command = r#"echo -n "<username>:<password>" | base64"#;
-    let specific_instructions = match transport {
-        transport::Transport::Ssh {
-            auth: ssh::Auth::KeyFile(key_path),
-            endpoint,
-        } => {
-            let key_path = key_path.to_string_lossy();
-            let command = format!(
-                r#"GIT_SSH_COMMAND="ssh -i {} -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -F /dev/null" git ls-remote {}"#,
-                key_path, endpoint
-            ).green();
-            formatdoc!(
-                "You are using SSH keyfile authentication for this remote. This connects to your repository by setting the `GIT_SSH_COMMAND` environment variable with the path to the ssh key that you provided in your config file. Please make sure you can run the following command to verify the connection:
-
-                {}", command
-            )
-        }
-        transport::Transport::Ssh {
-            auth: ssh::Auth::KeyValue(_),
-            endpoint,
-        } => {
-            let command = format!(
-                r#"GIT_SSH_COMMAND="ssh -i <path with ssh key> -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -F /dev/null" git ls-remote {}"#,
-                endpoint
-            ).green();
-            formatdoc!(
-                "You are using SSH key authentication for this remote. This method of authentication writes the SSH key that you provided in your config file to a temporary file, and then connects to your repository by setting the `GIT_SSH_COMMAND` environment variable with the path to the temporary file. To debug this, please write the ssh key to a file and then make sure you can run the following command to verify the connection.
-
-                The path with the ssh key in it must have permissions of 0x660 on Linux and MacOS.
-
-                {}", command
-            )
-        }
-        transport::Transport::Http {
-            auth: Some(http::Auth::Basic { .. }),
-            endpoint,
-        } => {
-            let command = format!(
-                r#"git -c "http.extraHeader=Authorization: Basic <base64 encoded username and password>" {}"#,
-                endpoint
-            )
-            .green();
-
-            formatdoc!(
-                r#"You are using HTTP basic authentication for this remote. This method of authentication encodes the username and password as a base64 string and then passes that to git using the "http.extraHeader" parameter. To debug this, please make sure that the following commands work.
-
-                You generate the base64 encoded username and password by joining them with a ":" and then base64 encoding them. If your username was "pat" and your password was "password123", then you would base64 encode "pat:password123". For example, you can use a command like this:
-
-                {}
-
-                Once you have the base64 encoded username and password, use them in a command like this:
-
-                {}"#,
-                base64_command,
-                command
-            )
-        }
-        transport::Transport::Http {
-            auth: Some(http::Auth::Header { .. }),
-            endpoint,
-        } => {
-            let command = format!(
-                r#"git -c "http.extraHeader=<your header>" ls-remote {}"#,
-                endpoint
-            )
-            .green();
-            formatdoc!(
-                r#"You are using HTTP header authentication for this remote. This method of authentication passes the header that you have provided in your config file to git using the "http.extraHeader" parameter. To debug this, please make sure the following command works, making sure to substitute the header from your config file into the right spot:
-
-                {}
-
-                You generate the header by making a string that looks like this:
-
-                Authorization: Basic <base64 encoded username:password>
-
-                If your username was "pat" and your password was "password123", then you would base64 encode "pat:password123". For example, you can use a command like this:
-
-                {}
-
-                The username you use depends on the git hosting platform you are authenticating to. For details on this, please see the `config.example.yml` file in your broker config directory. You can re-generate this file at any time by running `broker init`.
-                "#,
-                command,
-                base64_command
-            )
-        }
-        transport::Transport::Http {
-            auth: None,
-            endpoint,
-        } => {
-            let command = format!("git ls-remote {}", endpoint).green();
-            formatdoc!(
-                r#"You are using http transport with no authentication for this integration. To debug this, please make sure that the following command works:
-
-                {}"#,
-                command
-            )
-        }
-    };
-
-    format!("{}\n\n{}", shared_instructions, specific_instructions)
 }
 
 #[tracing::instrument(skip(ctx))]

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -103,7 +103,7 @@ impl Error {
     #[tracing::instrument]
     fn integration_connection_explanation(transport: &transport::Transport) -> String {
         let shared_instructions = "We were unable to connect to this repository. Please make sure that the authentication info and the remote are set correctly in your config.yml file.";
-        let base64_command = r#"echo -n "<username>:<password>" | base64"#;
+        let base64_command = r#"echo -n "<username>:<password>" | base64"#.green();
         let specific_instructions = match transport {
             transport::Transport::Ssh {
                 auth: ssh::Auth::KeyFile(key_path),

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -80,7 +80,15 @@ impl Error {
     ) -> Self {
         let msg = formatdoc!(
             "
-        We encountered an error while trying to connect to your git remote at {}.\n\n{}\n\nFull error message from git:\n\n{}\n\n",
+            We encountered an error while trying to connect to your git remote at {}.
+
+            {}
+
+            Full error message from git:
+
+            {}
+
+            ",
             remote,
             Self::integration_connection_explanation(transport),
             err.to_string(),
@@ -103,51 +111,50 @@ impl Error {
             } => {
                 let key_path = key_path.to_string_lossy();
                 let command = format!(
-                r#"GIT_SSH_COMMAND="ssh -i {} -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -F /dev/null" git ls-remote {}"#,
-                key_path, endpoint
-            ).green();
+                    r#"GIT_SSH_COMMAND="ssh -i {} -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -F /dev/null" git ls-remote {}"#,
+                    key_path, endpoint
+                ).green();
                 formatdoc!(
-                "You are using SSH keyfile authentication for this remote. This connects to your repository by setting the `GIT_SSH_COMMAND` environment variable with the path to the ssh key that you provided in your config file. Please make sure you can run the following command to verify the connection:
+                    "You are using SSH keyfile authentication for this remote. This connects to your repository by setting the `GIT_SSH_COMMAND` environment variable with the path to the ssh key that you provided in your config file. Please make sure you can run the following command to verify the connection:
 
-                {}", command
-            )
+                    {}", command
+                )
             }
             transport::Transport::Ssh {
                 auth: ssh::Auth::KeyValue(_),
                 endpoint,
             } => {
                 let command = format!(
-                r#"GIT_SSH_COMMAND="ssh -i <path with ssh key> -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -F /dev/null" git ls-remote {}"#,
-                endpoint
-            ).green();
+                    r#"GIT_SSH_COMMAND="ssh -i <path with ssh key> -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -F /dev/null" git ls-remote {}"#,
+                    endpoint
+                ).green();
                 formatdoc!(
-                "You are using SSH key authentication for this remote. This method of authentication writes the SSH key that you provided in your config file to a temporary file, and then connects to your repository by setting the `GIT_SSH_COMMAND` environment variable with the path to the temporary file. To debug this, please write the ssh key to a file and then make sure you can run the following command to verify the connection.
+                    "You are using SSH key authentication for this remote. This method of authentication writes the SSH key that you provided in your config file to a temporary file, and then connects to your repository by setting the `GIT_SSH_COMMAND` environment variable with the path to the temporary file. To debug this, please write the ssh key to a file and then make sure you can run the following command to verify the connection.
 
-                The path with the ssh key in it must have permissions of 0x660 on Linux and MacOS.
+                    The path with the ssh key in it must have permissions of 0x660 on Linux and MacOS.
 
-                {}", command
-            )
+                    {}", command
+                )
             }
             transport::Transport::Http {
                 auth: Some(http::Auth::Basic { .. }),
                 endpoint,
             } => {
                 let command = format!(
-                r#"git -c "http.extraHeader=Authorization: Basic <base64 encoded username and password>" {}"#,
-                endpoint
-            )
-            .green();
+                    r#"git -c "http.extraHeader=Authorization: Basic <base64 encoded username and password>" {}"#,
+                    endpoint
+                ).green();
 
                 formatdoc!(
                     r#"You are using HTTP basic authentication for this remote. This method of authentication encodes the username and password as a base64 string and then passes that to git using the "http.extraHeader" parameter. To debug this, please make sure that the following commands work.
 
-                You generate the base64 encoded username and password by joining them with a ":" and then base64 encoding them. If your username was "pat" and your password was "password123", then you would base64 encode "pat:password123". For example, you can use a command like this:
+                    You generate the base64 encoded username and password by joining them with a ":" and then base64 encoding them. If your username was "pat" and your password was "password123", then you would base64 encode "pat:password123". For example, you can use a command like this:
 
-                {}
+                    {}
 
-                Once you have the base64 encoded username and password, use them in a command like this:
+                    Once you have the base64 encoded username and password, use them in a command like this:
 
-                {}"#,
+                    {}"#,
                     base64_command,
                     command
                 )
@@ -164,18 +171,18 @@ impl Error {
                 formatdoc!(
                     r#"You are using HTTP header authentication for this remote. This method of authentication passes the header that you have provided in your config file to git using the "http.extraHeader" parameter. To debug this, please make sure the following command works, making sure to substitute the header from your config file into the right spot:
 
-                {}
+                    {}
 
-                You generate the header by making a string that looks like this:
+                    You generate the header by making a string that looks like this:
 
-                Authorization: Basic <base64 encoded username:password>
+                    Authorization: Basic <base64 encoded username:password>
 
-                If your username was "pat" and your password was "password123", then you would base64 encode "pat:password123". For example, you can use a command like this:
+                    If your username was "pat" and your password was "password123", then you would base64 encode "pat:password123". For example, you can use a command like this:
 
-                {}
+                    {}
 
-                The username you use depends on the git hosting platform you are authenticating to. For details on this, please see the `config.example.yml` file in your broker config directory. You can re-generate this file at any time by running `broker init`.
-                "#,
+                    The username you use depends on the git hosting platform you are authenticating to. For details on this, please see the `config.example.yml` file in your broker config directory. You can re-generate this file at any time by running `broker init`.
+                    "#,
                     command,
                     base64_command
                 )
@@ -188,7 +195,7 @@ impl Error {
                 formatdoc!(
                     r#"You are using http transport with no authentication for this integration. To debug this, please make sure that the following command works:
 
-                {}"#,
+                    {}"#,
                     command
                 )
             }
@@ -262,22 +269,22 @@ impl Error {
         err: reqwest::Error,
     ) -> String {
         formatdoc!(
-        "{}
+            "{}
 
-        {}
+            {}
 
-        The URL we attempted to connect to was {}. Please make sure you can make a request to that URL. For example, try this curl command:
+            The URL we attempted to connect to was {}. Please make sure you can make a request to that URL. For example, try this curl command:
 
-        {}
+            {}
 
-        Full error message: {}
-        ",
-        description.red(),
-        specific_error_message,
-        url,
-        example_command.green(),
-        err
-    )
+            Full error message: {}
+            ",
+            description.red(),
+            specific_error_message,
+            url,
+            example_command.green(),
+            err
+        )
     }
 }
 

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -287,26 +287,20 @@ pub async fn main(config: &Config) -> Result<(), Report<Error>> {
     let integration_errors = check_integrations(config).await;
     let fossa_connection_errors = check_fossa_connection(config).await;
     print_errors(
-        "Errors found while checking integrations"
-            .bold()
-            .red()
-            .to_string(),
+        "\nErrors found while checking integrations",
         integration_errors,
     );
     print_errors(
-        "Errors found while checking connection to FOSSA"
-            .bold()
-            .red()
-            .to_string(),
+        "\nErrors found while checking connection to FOSSA",
         fossa_connection_errors,
     );
     Ok(())
 }
 
 #[tracing::instrument]
-fn print_errors(msg: String, errors: Vec<Error>) {
+fn print_errors(msg: &str, errors: Vec<Error>) {
     if !errors.is_empty() {
-        println!("\n{}\n", msg,);
+        println!("{}\n", msg.bold().red());
         for err in errors {
             println!("{}", err.fix_explanation());
         }

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -54,6 +54,7 @@ pub enum Error {
 }
 
 impl Error {
+    #[tracing::instrument]
     fn fix_explanation(&self) -> String {
         match self {
             Error::CheckIntegration { remote, msg, .. } => {
@@ -71,6 +72,7 @@ impl Error {
         }
     }
 
+    #[tracing::instrument]
     fn integration_error(
         remote: &Remote,
         transport: &Transport,
@@ -90,6 +92,7 @@ impl Error {
         }
     }
 
+    #[tracing::instrument]
     fn integration_connection_explanation(transport: &transport::Transport) -> String {
         let shared_instructions = "We were unable to connect to this repository. Please make sure that the authentication info and the remote are set correctly in your config.yml file.";
         let base64_command = r#"echo -n "<username>:<password>" | base64"#;
@@ -194,6 +197,7 @@ impl Error {
         format!("{}\n\n{}", shared_instructions, specific_instructions)
     }
 
+    #[tracing::instrument]
     fn fossa_integration_error(
         status: Option<reqwest::StatusCode>,
         err: reqwest::Error,
@@ -249,6 +253,7 @@ impl Error {
         }
     }
 
+    #[tracing::instrument]
     fn fossa_get_explanation(
         description: &str,
         specific_error_message: &str,
@@ -377,6 +382,7 @@ async fn check_fossa_connection(config: &Config) -> Vec<Error> {
 
 const FOSSA_CONNECT_TIMEOUT_IN_SECONDS: u64 = 30;
 
+#[tracing::instrument(skip(config))]
 async fn check_fossa_get_with_no_auth(config: &Config) -> Result<(), Error> {
     let endpoint = config.fossa_api().endpoint().as_ref();
     let path = "/api/cli/organization";
@@ -411,6 +417,7 @@ async fn check_fossa_get_with_no_auth(config: &Config) -> Result<(), Error> {
     )
 }
 
+#[tracing::instrument(skip(config))]
 async fn check_fossa_get_with_auth(config: &Config) -> Result<(), Error> {
     let endpoint = config.fossa_api().endpoint().as_ref();
     let path = "/api/cli/organization";
@@ -446,6 +453,7 @@ async fn check_fossa_get_with_auth(config: &Config) -> Result<(), Error> {
     )
 }
 
+#[tracing::instrument]
 fn describe_fossa_request(
     response: Result<reqwest::Response, reqwest::Error>,
     description: &str,

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -216,10 +216,7 @@ impl Error {
             Some(reqwest::StatusCode::UNAUTHORIZED) => Error::CheckFossaGet {
                 msg: Self::fossa_get_explanation(
                     description,
-                    &format!(
-                        r#"We received an "Unauthorized" status response from FOSSA. This can mean that the fossa_integration_key configured in your config.yml file is not correct. You can obtain a FOSSA API key at {}/account/settings/integrations/api_tokens."#,
-                        url
-                    ),
+                    r#"We received an "Unauthorized" status response from FOSSA. This can mean that the fossa_integration_key configured in your config.yml file is not correct. You can obtain a FOSSA API key by going to Settings => Integrations => API in the FOSSA application."#,
                     url,
                     example_command,
                     err,

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -26,7 +26,7 @@ use crate::{
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Check an integration
-    #[error("check integration for {}\n{}", remote, error)]
+    #[error("check integration for {remote}\n{error}")]
     CheckIntegration {
         /// the remote that the integration check failed for
         remote: Remote,
@@ -37,14 +37,14 @@ pub enum Error {
     },
 
     /// Make a GET request to a fossa endpoint that does not require authentication
-    #[error("check fossa connection: {}", msg)]
+    #[error("check fossa connection: {msg}")]
     CheckFossaGet {
         /// An error message explaining how to fix this GET from FOSSA
         msg: String,
     },
 
     /// Creating a full URL from the provided endpoint
-    #[error("create FOSSA URL from endpoint {}/{}", remote, path)]
+    #[error("create FOSSA URL from endpoint {remote}/{path}")]
     CreateFullFossaUrl {
         /// The configured fossa URL
         remote: url::Url,

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -283,7 +283,6 @@ pub async fn main(config: &Config) -> Result<(), Report<Error>> {
 // If there are errors, returns a string containing all of the error messages for a section.
 // Sections are things like "checking integrations" or "checking fossa connection"
 // If there are no errors, it returns None.
-#[tracing::instrument]
 fn print_errors(msg: &str, errors: Vec<Error>) {
     if !errors.is_empty() {
         println!("{}\n", msg.bold().red());
@@ -306,12 +305,13 @@ async fn check_integrations(config: &Config) -> Vec<Error> {
     let integrations = config.integrations();
     let mut errors = Vec::new();
     for integration in integrations.iter() {
+        let remote = integration.remote();
         match check_integration(integration).await {
             Ok(()) => {
-                println!("✅ {}", integration.remote())
+                println!("✅ {remote}")
             }
             Err(err) => {
-                println!("❌ {}", integration.remote());
+                println!("❌ {remote}");
                 errors.push(err);
             }
         }
@@ -339,7 +339,7 @@ async fn check_fossa_connection(config: &Config) -> Vec<Error> {
 
     let get_with_no_auth = check_fossa_get_with_no_auth(config).await;
     match get_with_no_auth {
-        Ok(()) => {
+        Ok(_) => {
             println!("✅ check fossa API connection with no auth required");
         }
         Err(err) => {
@@ -349,7 +349,7 @@ async fn check_fossa_connection(config: &Config) -> Vec<Error> {
     }
     let get_with_auth = check_fossa_get_with_auth(config).await;
     match get_with_auth {
-        Ok(()) => {
+        Ok(_) => {
             println!("✅ check fossa API connection with auth required");
         }
         Err(err) => {

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -230,14 +230,14 @@ impl Error {
             None => {
                 if err.is_timeout() {
                     Error::CheckFossaGet {
-                    msg: Self::fossa_get_explanation(
-                        description,
-                        "We received a timeout error while attempting to connect to FOSSA. This can happen if we are unable to connect to FOSSA due to various reasons.",
-                        url,
-                        example_command,
-                        err,
-                    ),
-                }
+                        msg: Self::fossa_get_explanation(
+                            description,
+                            "We received a timeout error while attempting to connect to FOSSA. This can happen if we are unable to connect to FOSSA due to various reasons.",
+                            url,
+                            example_command,
+                            err,
+                        ),
+                    }
                 } else {
                     Error::CheckFossaGet {
                         msg: Self::fossa_get_explanation(
@@ -297,6 +297,9 @@ pub async fn main(config: &Config) -> Result<(), Report<Error>> {
     Ok(())
 }
 
+// If there are errors, returns a string containing all of the error messages for a section.
+// A section is either "checking integrations" or "checking fossa connection"
+// If there are no errors, it returns None.
 #[tracing::instrument]
 fn print_errors(msg: &str, errors: Vec<Error>) {
     if !errors.is_empty() {

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -172,10 +172,10 @@ fn protocol_connection_explanation(transport: &transport::Transport) -> String {
                 key_path, endpoint
             ).green();
             formatdoc!(
-            "You are using SSH keyfile authentication for this remote. This connects to your repository by setting the `GIT_SSH_COMMAND` environment variable with the path to the ssh key that you provided in your config file. Please make sure you can run the following command to verify the connection:
+                "You are using SSH keyfile authentication for this remote. This connects to your repository by setting the `GIT_SSH_COMMAND` environment variable with the path to the ssh key that you provided in your config file. Please make sure you can run the following command to verify the connection:
 
-            {}", command
-        )
+                {}", command
+            )
         }
         transport::Transport::Ssh {
             auth: ssh::Auth::KeyValue(_),
@@ -186,12 +186,12 @@ fn protocol_connection_explanation(transport: &transport::Transport) -> String {
                 endpoint
             ).green();
             formatdoc!(
-            "You are using SSH key authentication for this remote. This method of authentication writes the SSH key that you provided in your config file to a temporary file, and then connects to your repository by setting the `GIT_SSH_COMMAND` environment variable with the path to the temporary file. To debug this, please write the ssh key to a file and then make sure you can run the following command to verify the connection.
+                "You are using SSH key authentication for this remote. This method of authentication writes the SSH key that you provided in your config file to a temporary file, and then connects to your repository by setting the `GIT_SSH_COMMAND` environment variable with the path to the temporary file. To debug this, please write the ssh key to a file and then make sure you can run the following command to verify the connection.
 
-            The path with the ssh key in it must have permissions of 0x660 on Linux and MacOS.
+                The path with the ssh key in it must have permissions of 0x660 on Linux and MacOS.
 
-            {}", command
-        )
+                {}", command
+            )
         }
         transport::Transport::Http {
             auth: Some(http::Auth::Basic { .. }),
@@ -234,7 +234,18 @@ fn protocol_connection_explanation(transport: &transport::Transport) -> String {
                 command
             )
         }
-        transport::Transport::Http { auth: None, .. } => "".to_string(),
+        transport::Transport::Http {
+            auth: None,
+            endpoint,
+        } => {
+            let command = format!("git ls-remote {}", endpoint).green();
+            formatdoc!(
+                r#"You are using http transport with no authentication for this integration. To debug this, please make sure that the following command works:
+
+                {}"#,
+                command
+            )
+        }
     };
 
     format!("{}\n\n{}", shared_instructions, specific_instructions)

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -1,9 +1,10 @@
 //! Implementation for the fix command
 
-use error_stack::{Report, ResultExt};
+use colored::Colorize;
+use error_stack::{Report, Result};
 
 use crate::{
-    api::remote::{git::repository, Integration, Protocol},
+    api::remote::{git::repository, Integration, Protocol, Remote},
     config::Config,
     ext::tracing::span_record,
     AppContext,
@@ -13,15 +14,20 @@ use crate::{
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Check the integration
-    #[error("check integration")]
-    CheckIntegration,
+    #[error("checking integration for {}\n{}", remote, error)]
+    CheckIntegration {
+        /// the remote that the integration check failed for
+        remote: Remote,
+        /// the error returned by the integration check
+        error: String,
+    },
 }
 
 /// Similar to [`AppContext`], but scoped for this subcommand.
 #[derive(Debug)]
 struct CmdContext {
     /// The application context.
-    app: AppContext,
+    // app: AppContext,
 
     /// The application configuration.
     config: Config,
@@ -29,35 +35,59 @@ struct CmdContext {
 
 /// The primary entrypoint for the fix command.
 #[tracing::instrument(skip_all, fields(subcommand = "fix", cmd_context))]
-pub async fn main(ctx: &AppContext, config: Config) -> Result<(), Report<Error>> {
+pub async fn main(_ctx: &AppContext, config: Config) -> Result<(), Report<Error>> {
     let ctx = CmdContext {
-        app: ctx.clone(),
+        // app: ctx.clone(),
         config,
     };
     span_record!(cmd_context, debug ctx);
-    check_integrations(&ctx).await?;
-    Ok(())
-}
-
-async fn check_integrations(ctx: &CmdContext) -> Result<(), Report<Error>> {
-    println!("Diagnosing connections to configured repositories");
-    let integrations = ctx.config.integrations();
-    for integration in integrations.iter() {
-        check_integration(integration).await;
+    let integration_errors = check_integrations(&ctx).await;
+    if !integration_errors.is_empty() {
+        println!(
+            "\n{}\n",
+            "Errors found while checking integrations".bold().red()
+        );
+        for error in integration_errors {
+            println!("{}", error);
+        }
     }
     Ok(())
 }
 
+async fn check_integrations(ctx: &CmdContext) -> Vec<String> {
+    let title = "Diagnosing connections to configured repositories\n"
+        .bold()
+        .blue()
+        .to_string();
+    println!("{}", title);
+    let integrations = ctx.config.integrations();
+    let mut errors = Vec::new();
+    for integration in integrations.iter() {
+        match check_integration(integration).await {
+            Ok(()) => {
+                println!("✅ {}", integration.remote())
+            }
+            Err(err) => {
+                println!("❌ {}", integration.remote());
+                errors.push(err.to_string());
+            }
+        }
+    }
+    errors
+}
+
 #[tracing::instrument]
-async fn check_integration(integration: &Integration) {
+async fn check_integration(integration: &Integration) -> Result<(), Error> {
     let Protocol::Git(transport) = integration.protocol();
     let result = repository::ls_remote(transport);
     match result {
-        Ok(_) => {
-            println!("✅ {}\n", integration.remote());
-        }
+        Ok(_) => Ok(()),
         Err(err) => {
-            println!("❌ {}:\n{}\n", integration.remote(), err);
+            let error = Error::CheckIntegration {
+                remote: integration.remote().clone(),
+                error: err.to_string(),
+            };
+            Err(err.change_context(error))
         }
     }
 }

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -315,9 +315,19 @@ fn describe_fossa_request(
                 .wrap_err()
             } else {
                 Error::CheckFossaGet {
-                    msg: format!(
-                        "{}: an error occurred while attempting to connect to FOSSA. {}",
-                        prefix, err
+                    msg: formatdoc!(
+                        "{}
+                        an error occurred while attempting to connect to FOSSA.
+
+                        The URL we attempted to connect to was {}.
+
+                        Please make sure you can make a request to that URL. For example, try this curl command:
+
+                        {}
+
+                        Full error message: {}
+                        ",
+                        prefix, url, example_command, err
                     ),
                 }
                 .wrap_err()

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -170,7 +170,7 @@ impl Error {
                 ..
             } => {
                 formatdoc!(
-                    r#"You are using HTTP header authentication for this remote. This method of authentication passes the header that you have provided in your config file to git using the "http.extraHeader" parameter. To debug this, please make sure the following command works, making sure to substitute the header from your config file into the right spot:
+                    r#"You are using HTTP header authentication for this remote. This method of authentication passes the header that you have provided in your config file to git using the "http.extraHeader" parameter. To debug this, please make sure the following command works, after replacing {REDACTION_LITERAL} with the header from your config file:
 
                     {command}
 

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -19,7 +19,7 @@ use crate::{
         ssh,
     },
     config::Config,
-    ext::{result::WrapErr, tracing::span_record},
+    ext::result::WrapErr,
 };
 
 /// Errors encountered when running the fix command.
@@ -276,26 +276,11 @@ impl Error {
     }
 }
 
-/// Similar to [`AppContext`], but scoped for this subcommand.
-#[derive(Debug)]
-struct CmdContext {
-    /// The application context.
-    // app: AppContext,
-
-    /// The application configuration.
-    config: Config,
-}
-
 /// The primary entrypoint for the fix command.
-#[tracing::instrument(skip_all, fields(subcommand = "fix", cmd_context))]
-pub async fn main(config: Config) -> Result<(), Report<Error>> {
-    let ctx = CmdContext {
-        // app: ctx.clone(),
-        config,
-    };
-    span_record!(cmd_context, debug ctx);
-    let integration_errors = check_integrations(&ctx).await;
-    let fossa_connection_errors = check_fossa_connection(&ctx).await;
+#[tracing::instrument(skip_all, fields(subcommand = "fix"))]
+pub async fn main(config: &Config) -> Result<(), Report<Error>> {
+    let integration_errors = check_integrations(config).await;
+    let fossa_connection_errors = check_fossa_connection(config).await;
     print_errors(
         "Errors found while checking integrations"
             .bold()
@@ -326,14 +311,14 @@ fn print_errors(msg: String, errors: Vec<Error>) {
 /// Check that we can connect to the integrations
 /// This is currently done by running `git ls-remote <remote>` using the authentication
 /// info from the transport.
-#[tracing::instrument(skip(ctx))]
-async fn check_integrations(ctx: &CmdContext) -> Vec<Error> {
+#[tracing::instrument(skip(config))]
+async fn check_integrations(config: &Config) -> Vec<Error> {
     let title = "\nDiagnosing connections to configured repositories\n"
         .bold()
         .blue()
         .to_string();
     println!("{}", title);
-    let integrations = ctx.config.integrations();
+    let integrations = config.integrations();
     let mut errors = Vec::new();
     for integration in integrations.iter() {
         match check_integration(integration).await {
@@ -357,8 +342,8 @@ async fn check_integration(integration: &Integration) -> Result<(), Error> {
     Ok(())
 }
 
-#[tracing::instrument(skip(ctx))]
-async fn check_fossa_connection(ctx: &CmdContext) -> Vec<Error> {
+#[tracing::instrument(skip(config))]
+async fn check_fossa_connection(config: &Config) -> Vec<Error> {
     let title = "\nDiagnosing connection to FOSSA\n"
         .bold()
         .blue()
@@ -366,7 +351,7 @@ async fn check_fossa_connection(ctx: &CmdContext) -> Vec<Error> {
     println!("{}", title);
     let mut errors = Vec::new();
 
-    let get_with_no_auth = check_fossa_get_with_no_auth(ctx).await;
+    let get_with_no_auth = check_fossa_get_with_no_auth(config).await;
     match get_with_no_auth {
         Ok(()) => {
             println!("✅ check fossa API connection with no auth required");
@@ -376,7 +361,7 @@ async fn check_fossa_connection(ctx: &CmdContext) -> Vec<Error> {
             errors.push(err)
         }
     }
-    let get_with_auth = check_fossa_get_with_auth(ctx).await;
+    let get_with_auth = check_fossa_get_with_auth(config).await;
     match get_with_auth {
         Ok(()) => {
             println!("✅ check fossa API connection with auth required");
@@ -392,8 +377,8 @@ async fn check_fossa_connection(ctx: &CmdContext) -> Vec<Error> {
 
 const FOSSA_CONNECT_TIMEOUT_IN_SECONDS: u64 = 30;
 
-async fn check_fossa_get_with_no_auth(ctx: &CmdContext) -> Result<(), Error> {
-    let endpoint = ctx.config.fossa_api().endpoint().as_ref();
+async fn check_fossa_get_with_no_auth(config: &Config) -> Result<(), Error> {
+    let endpoint = config.fossa_api().endpoint().as_ref();
     let path = "/api/cli/organization";
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -426,8 +411,8 @@ async fn check_fossa_get_with_no_auth(ctx: &CmdContext) -> Result<(), Error> {
     )
 }
 
-async fn check_fossa_get_with_auth(ctx: &CmdContext) -> Result<(), Error> {
-    let endpoint = ctx.config.fossa_api().endpoint().as_ref();
+async fn check_fossa_get_with_auth(config: &Config) -> Result<(), Error> {
+    let endpoint = config.fossa_api().endpoint().as_ref();
     let path = "/api/cli/organization";
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -444,7 +429,7 @@ async fn check_fossa_get_with_auth(ctx: &CmdContext) -> Result<(), Error> {
     let org_endpoint_response = client
         .get(url.as_str())
         .header(reqwest::header::ACCEPT, "application/json")
-        .bearer_auth(ctx.config.fossa_api().key().expose_secret())
+        .bearer_auth(config.fossa_api().key().expose_secret())
         .send()
         .await;
     describe_fossa_request(

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -391,12 +391,14 @@ async fn check_fossa_connection(ctx: &CmdContext) -> Vec<Error> {
     errors
 }
 
+const FOSSA_CONNECT_TIMEOUT_IN_SECONDS: u64 = 30;
+
 async fn check_fossa_get_with_no_auth(ctx: &CmdContext) -> Result<(), Error> {
     let endpoint = ctx.config.fossa_api().endpoint().as_ref();
     let path = "/api/cli/organization";
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
-        .connect_timeout(Duration::from_secs(1))
+        .connect_timeout(Duration::from_secs(FOSSA_CONNECT_TIMEOUT_IN_SECONDS))
         .build()
         .map_err(|_| Error::CreateFullFossaUrl {
             remote: endpoint.clone(),
@@ -430,7 +432,7 @@ async fn check_fossa_get_with_auth(ctx: &CmdContext) -> Result<(), Error> {
     let path = "/api/cli/organization";
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
-        .connect_timeout(Duration::from_secs(1))
+        .connect_timeout(Duration::from_secs(FOSSA_CONNECT_TIMEOUT_IN_SECONDS))
         .build()
         .map_err(|_| Error::CreateFullFossaUrl {
             remote: endpoint.clone(),

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -1,0 +1,63 @@
+//! Implementation for the fix command
+
+use error_stack::{Report, ResultExt};
+
+use crate::{
+    api::remote::{git::repository, Integration, Protocol},
+    config::Config,
+    ext::tracing::span_record,
+    AppContext,
+};
+
+/// Errors encountered when running the fix command.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Check the integration
+    #[error("check integration")]
+    CheckIntegration,
+}
+
+/// Similar to [`AppContext`], but scoped for this subcommand.
+#[derive(Debug)]
+struct CmdContext {
+    /// The application context.
+    app: AppContext,
+
+    /// The application configuration.
+    config: Config,
+}
+
+/// The primary entrypoint for the fix command.
+#[tracing::instrument(skip_all, fields(subcommand = "fix", cmd_context))]
+pub async fn main(ctx: &AppContext, config: Config) -> Result<(), Report<Error>> {
+    let ctx = CmdContext {
+        app: ctx.clone(),
+        config,
+    };
+    span_record!(cmd_context, debug ctx);
+    check_integrations(&ctx).await?;
+    Ok(())
+}
+
+async fn check_integrations(ctx: &CmdContext) -> Result<(), Report<Error>> {
+    println!("Diagnosing connections to configured repositories");
+    let integrations = ctx.config.integrations();
+    for integration in integrations.iter() {
+        check_integration(integration).await;
+    }
+    Ok(())
+}
+
+#[tracing::instrument]
+async fn check_integration(integration: &Integration) {
+    let Protocol::Git(transport) = integration.protocol();
+    let result = repository::ls_remote(transport);
+    match result {
+        Ok(_) => {
+            println!("✅ {}\n", integration.remote());
+        }
+        Err(err) => {
+            println!("❌ {}:\n{}\n", integration.remote(), err);
+        }
+    }
+}

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -258,11 +258,7 @@ fn describe_fossa_request(
                         Error::CheckFossaGet {
                            msg: fossa_error_explanation(
                              prefix,
-                             &formatdoc!(r#"We received an "Unauthorized" status response from FOSSA.
-
-                                This can mean that the fossa_integration_key configured in your config.yml file is not correct.
-
-                                You can obtain a FOSSA API key at {}/account/settings/integrations/api_tokens."#, url),
+                             &format!(r#"We received an "Unauthorized" status response from FOSSA. This can mean that the fossa_integration_key configured in your config.yml file is not correct. You can obtain a FOSSA API key at {}/account/settings/integrations/api_tokens."#, url),
                              url,
                              example_command,
                              status_err,
@@ -292,9 +288,7 @@ fn describe_fossa_request(
                 Error::CheckFossaGet {
                     msg: fossa_error_explanation(
                         prefix,
-                        &formatdoc!("We received a timeout error while attempting to connect to FOSSA.
-
-                        This can happen if we are unable to connect to FOSSA due to various reasons."),
+                        "We received a timeout error while attempting to connect to FOSSA. This can happen if we are unable to connect to FOSSA due to various reasons.",
                         url,
                         example_command,
                         err,
@@ -329,9 +323,7 @@ fn fossa_error_explanation(
 
         {}
 
-        The URL we attempted to connect to was {}.
-
-        Please make sure you can make a request to that URL. For example, try this curl command:
+        The URL we attempted to connect to was {}. Please make sure you can make a request to that URL. For example, try this curl command:
 
         {}
 
@@ -340,7 +332,7 @@ fn fossa_error_explanation(
         prefix.red(),
         specific_error_message,
         url,
-        example_command,
+        example_command.green(),
         err
     )
 }

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -181,8 +181,22 @@ fn protocol_connection_explanation(transport: &transport::Transport) -> String {
         }
         transport::Transport::Ssh {
             auth: ssh::Auth::KeyValue(_),
-            ..
-        } => "".to_string(),
+            endpoint,
+        } => {
+            let command = format!(
+                r#"GIT_SSH_COMMAND="ssh -i <path with ssh key> -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -F /dev/null" git ls-remote {}"#,
+                endpoint
+            ).green();
+            formatdoc!(
+            "You are using SSH key authentication for this remote. This method of authentication writes the SSH key that you provided in your config file to a temporary file, and then connects to your repository by setting the `GIT_SSH_COMMAND` environment variable with the path to the temporary file. To debug this, please write the ssh key to a file and then make sure you can run the following command to verify the connection.
+
+            The path with the ssh key in it must have permissions of 0x660 on Linux and MacOS.
+
+            {}
+
+            ", command
+        )
+        }
         transport::Transport::Http {
             auth: Some(http::Auth::Basic { .. }),
             ..

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -20,7 +20,7 @@ use crate::{
         ssh,
     },
     config::Config,
-    ext::{command::CommandDescriber, result::WrapErr},
+    ext::result::WrapErr,
 };
 
 /// Errors encountered when running the fix command.
@@ -116,13 +116,9 @@ impl Error {
         // Generate an example command. The basic command is `git ls-remote`, but there are other arguments and env variables added
         // depending on the auth used.
         // The resulting command should be an exact copy of the command used by broker, and should work when pasted into the terminal.
-        let command = repository::construct_git_command(
-            transport,
-            &repository::ls_remote_args(transport),
-            None,
-        )
-        .or(Err(Error::GenerateExampleCommand))?;
-        let command = command.describe().pastable().green();
+        let command = repository::pastable_ls_remote_command(transport)
+            .or(Err(Error::GenerateExampleCommand))
+            .map(|c| c.green())?;
 
         let specific_instructions = match transport {
             transport::Transport::Ssh {

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -347,6 +347,7 @@ async fn check_integrations(config: &Config) -> Vec<Error> {
 async fn check_integration(integration: &Integration) -> Result<(), Error> {
     let Protocol::Git(transport) = integration.protocol();
     repository::ls_remote(transport)
+        .await
         .or_else(|err| Error::integration_error(integration.remote(), transport, err).wrap_err())?;
     Ok(())
 }

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -20,7 +20,6 @@ use crate::{
     },
     config::Config,
     ext::{result::WrapErr, tracing::span_record},
-    AppContext,
 };
 
 /// Errors encountered when running the fix command.
@@ -289,7 +288,7 @@ struct CmdContext {
 
 /// The primary entrypoint for the fix command.
 #[tracing::instrument(skip_all, fields(subcommand = "fix", cmd_context))]
-pub async fn main(_ctx: &AppContext, config: Config) -> Result<(), Report<Error>> {
+pub async fn main(config: Config) -> Result<(), Report<Error>> {
     let ctx = CmdContext {
         // app: ctx.clone(),
         config,

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -141,7 +141,7 @@ impl Error {
                 endpoint,
             } => {
                 let command = format!(
-                    r#"git -c "http.extraHeader=Authorization: Basic <base64 encoded username and password>" {}"#,
+                    r#"git -c "http.extraHeader=Authorization: Basic <base64 encoded username and password>" ls-remote {}"#,
                     endpoint
                 ).green();
 

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -305,7 +305,7 @@ pub async fn main(config: &Config) -> Result<(), Report<Error>> {
 }
 
 // If there are errors, returns a string containing all of the error messages for a section.
-// A section is either "checking integrations" or "checking fossa connection"
+// Sections are things like "checking integrations" or "checking fossa connection"
 // If there are no errors, it returns None.
 #[tracing::instrument]
 fn print_errors(msg: &str, errors: Vec<Error>) {

--- a/src/subcommand/fix.rs
+++ b/src/subcommand/fix.rs
@@ -217,10 +217,7 @@ async fn check_fossa_get_with_auth(ctx: &CmdContext) -> Result<(), Error> {
     let org_endpoint_response = client
         .get(url.as_str())
         .header(reqwest::header::ACCEPT, "application/json")
-        .header(
-            reqwest::header::AUTHORIZATION,
-            format!("Bearer {}", ctx.config.fossa_api().key().expose_secret()),
-        )
+        .bearer_auth(ctx.config.fossa_api().key().expose_secret())
         .send()
         .await;
     err_from_request(org_endpoint_response)

--- a/tests/it/snapshots/it__remote_git__clone_private_repo_with_no_auth.snap
+++ b/tests/it/snapshots/it__remote_git__clone_private_repo_with_no_auth.snap
@@ -8,7 +8,7 @@ run external command
 │
 ╰─▶ run command: git
     args: ["-c", "credential.helper=", "clone", "--filter=blob:none", "--branch", "main", "http://github.com/github/doesnotexist.git", {file path}]
-    env: ["GIT_TERMINAL_PROMPT=0", "GCM_INTERACTIVE=never", "GIT_ASKPASS=<REMOVED>"]
+    env: ["GIT_TERMINAL_PROMPT='0'", "GCM_INTERACTIVE='never'", "GIT_ASKPASS=<REMOVED>"]
     status: 128
     stdout: ''
     stderr: 'Cloning into {file path}...

--- a/tests/it/snapshots/it__remote_git__redacts_auth_http_basic.snap
+++ b/tests/it/snapshots/it__remote_git__redacts_auth_http_basic.snap
@@ -8,7 +8,7 @@ run external command
 │
 ╰─▶ run command: git
     args: ["-c", "credential.helper=", "-c", "http.extraHeader=AUTHORIZATION: Basic <REDACTED>", "clone", "--filter=blob:none", "--branch", "main", "https://github.com/fossas/does-not-exist.git", {file path}]
-    env: ["GIT_TERMINAL_PROMPT=0", "GCM_INTERACTIVE=never", "GIT_ASKPASS=<REMOVED>"]
+    env: ["GIT_TERMINAL_PROMPT='0'", "GCM_INTERACTIVE='never'", "GIT_ASKPASS=<REMOVED>"]
     status: 128
     stdout: ''
     stderr: 'Cloning into {file path}...

--- a/tests/it/snapshots/it__remote_git__redacts_auth_http_header.snap
+++ b/tests/it/snapshots/it__remote_git__redacts_auth_http_header.snap
@@ -8,7 +8,7 @@ run external command
 │
 ╰─▶ run command: git
     args: ["-c", "credential.helper=", "-c", "http.extraHeader=<REDACTED>", "clone", "--filter=blob:none", "--branch", "main", "https://github.com/fossas/does-not-exist.git", {file path}]
-    env: ["GIT_TERMINAL_PROMPT=0", "GCM_INTERACTIVE=never", "GIT_ASKPASS=<REMOVED>"]
+    env: ["GIT_TERMINAL_PROMPT='0'", "GCM_INTERACTIVE='never'", "GIT_ASKPASS=<REMOVED>"]
     status: 128
     stdout: ''
     stderr: 'Cloning into {file path}...

--- a/tests/it/snapshots/it__remote_git__references_on_private_repo_with_no_auth.snap
+++ b/tests/it/snapshots/it__remote_git__references_on_private_repo_with_no_auth.snap
@@ -10,7 +10,7 @@ run external command
 │   ╰╴at {source location}
 │
 ╰─▶ run command: git
-    args: ["-c", "credential.helper=", "ls-remote", "--quiet"]
+    args: ["-c", "credential.helper=", "ls-remote", "--quiet", "http://github.com/github/doesnotexist.git"]
     env: ["GCM_INTERACTIVE=never", "GIT_ASKPASS=<REMOVED>", "GIT_TERMINAL_PROMPT=0"]
     status: 128
     stdout: ''

--- a/tests/it/snapshots/it__remote_git__references_on_private_repo_with_no_auth.snap
+++ b/tests/it/snapshots/it__remote_git__references_on_private_repo_with_no_auth.snap
@@ -8,7 +8,7 @@ run external command
 │
 ╰─▶ run command: git
     args: ["-c", "credential.helper=", "ls-remote", "--quiet", "http://github.com/github/doesnotexist.git"]
-    env: ["GIT_TERMINAL_PROMPT=0", "GCM_INTERACTIVE=never", "GIT_ASKPASS=<REMOVED>"]
+    env: ["GIT_TERMINAL_PROMPT='0'", "GCM_INTERACTIVE='never'", "GIT_ASKPASS=<REMOVED>"]
     status: 128
     stdout: ''
     stderr: 'fatal: could not read Username for 'https://github.com': terminal prompts disabled'


### PR DESCRIPTION
# Overview

[Delivers ANE-839](https://fossa.atlassian.net/browse/ANE-839) - implement broker fix.

`broker fix` checks the connection to each integration that is set up in the config and also checks the connection to FOSSA.

This is a first pass at the `broker fix` functionality. We can definitely add more functionality in future PRs.

In this PR, we:

1) For each integration, we run `git ls-remote <remote URL>` with the appropriate environment variables and arguments for the integration's transport and authentication
2) Make a GET request to `<fossa url>/health` with no authentication
3) Make a GET request to `<fossa url>/api/cli/organization` authenticated with the FOSSA API key in your config.

## Acceptance criteria

* Customers get actionable information on how to fix problems with their integrations
* Customers get actionable information on how to fix problems with their connection to FOSSA

We will be refactoring this to make it testable, and adding tests, in a future PR (https://fossa.atlassian.net/browse/ANE-857).

## Testing plan

Make a `config.yml` with a connection to fossa staging. This is useful because you can turn your wireguard tunnel on and off to test the errors when connecting to FOSSA.

Add a few integrations to this config file. You can start with the configurations generated with `fossa init`.

```
cargo run -- init -r ~/tmp/broker-staging
```

edit the config in ~/tmp/broker-staging/config.yml. Here's a config file pointing at fossa staging with one integration pointing at a public repository:

```yaml
fossa_endpoint: https://staging.int.fossa.io
fossa_integration_key: abcd1234
version: 1

debugging:
  location: /Users/scott/tmp/broker-staging/debugging
  retention:
    days: 7

integrations:
  - type: git
    poll_interval: 1h
    remote: https://github.com/fossas/broker.git
    auth:
      type: none
      transport: http
```

```
cargo run -- fix
```

Run that with an invalid API key.  You should see instructions on how to fix the problem.

Fix the problem by putting in a valid API key and run it again. Everything should be green now.

Add some integrations with invalid authentication and/or with remotes that do not exist. Here's an example:

```yaml
integrations:
  - type: git
    poll_interval: 1h
    remote: git@github.com:fossas/FOSSA.git
    auth:
      type: ssh_key
      key: |
        -----BEGIN OPENSSH PRIVATE KEY-----
        contents of your private key
        -----END OPENSSH PRIVATE KEY-----

  - type: git
    poll_interval: 1h
    remote: https://github.com/fossas/doesnotexist.git
    auth:
      type: none
      transport: http

  - type: git
    poll_interval: 1h
    remote: https://github.com/fossas/basis.git
    auth:
      type: http_basic
      username: pat
      password: <ghp_the_rest_of_your_github_token>
```

Follow the instructions, making sure that the example commands work and everything makes sense. Try again and make sure that everything is green.

## Risks

None

## References

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
