### PR TITLE
CI Tweaks

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[registries.crates-io]
+protocol = "sparse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ license = "Apache-2.0"
 exclude = [ "docs", ".github" ]
 publish = false # rather than publishing this to crates.io, we'll provide releases here on GitHub.
 
+# Broker always tracks latest Rust, but this is the minimum required.
+rust-version = "1.68"
+
 [dependencies]
 bytesize = { version = "1.2.0", features = ["serde"] }
 clap = { version = "4.2.1", features = ["derive", "cargo", "env"] }

--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,4 @@ migrate-down:
 clippy:
 	@cargo clippy --all-targets --all-features -- -D warnings
 
-.PHONY: test run build dev review-snapshots generate-dist migration-status migrate-up migrate-down check-clippy
+.PHONY: test run build dev review-snapshots generate-dist migration-status migrate-up migrate-down clippy

--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,7 @@ migrate-up:
 migrate-down:
 	@cargo sqlx migrate revert --source db/migrations
 
-.PHONY: test run build dev review-snapshots generate-dist migration-status migrate-up migrate-down
+clippy:
+	@cargo clippy --all-targets --all-features -- -D warnings
+
+.PHONY: test run build dev review-snapshots generate-dist migration-status migrate-up migrate-down check-clippy


### PR DESCRIPTION
# Overview

Configures cargo to use the sparse registry protocol, which will improve CI performance: 
https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#cargos-sparse-protocol

Also adds `make clippy` for convenient local clippy checks.

