### PR TITLE
Disable dynamic analysis

### DIFF
--- a/src/ext/command.rs
+++ b/src/ext/command.rs
@@ -56,9 +56,6 @@ pub struct Command {
     /// `None` means they're cleared from the environment.
     envs: Vec<(String, Option<Value>)>,
 
-    /// Whether to clear the env of the child.
-    env_clear: bool,
-
     /// The working directory for the command.
     /// If not specified, defaults to the working directory of the current process.
     working_dir: Option<PathBuf>,
@@ -76,7 +73,6 @@ impl Command {
             envs: Vec::new(),
             name: command.as_ref().to_owned(),
             working_dir: None,
-            env_clear: false,
         }
     }
 
@@ -155,13 +151,6 @@ impl Command {
         self
     }
 
-    /// Normally environment variables are inherited from the host process (Broker itself).
-    /// This method clears all the inherited envs so the child starts with a blank slate.
-    pub fn env_clear(mut self) -> Self {
-        self.env_clear = true;
-        self
-    }
-
     /// Customizes the working directory for the command.
     pub fn current_dir<P: Into<PathBuf>>(mut self, dir: P) -> Self {
         self.working_dir = Some(dir.into());
@@ -209,10 +198,6 @@ impl Command {
     /// log any of its output directly.
     fn as_cmd(&self) -> tokio::process::Command {
         let mut cmd = tokio::process::Command::new(&self.name);
-
-        if self.env_clear {
-            cmd.env_clear();
-        }
 
         if let Some(working_dir) = &self.working_dir {
             cmd.current_dir(working_dir);

--- a/src/fossa_cli.rs
+++ b/src/fossa_cli.rs
@@ -164,6 +164,8 @@ impl Location {
         // We clear the env so that dynamic analysis strategies don't run.
         // This is intended to make Broker more predictable: users aren't surprised by
         // the presence or absence of build tools on their local system.
+        // In the future FOSSA CLI may have an option to enable this more gracefully;
+        // in such case we'll switch to that.
         let cmd = Command::new(&self.cli)
             .env_remove("PATH")
             .current_dir(tmp.path())

--- a/src/fossa_cli.rs
+++ b/src/fossa_cli.rs
@@ -160,7 +160,12 @@ impl Location {
         // this way trace events are recorded at the time the CLI actually logs them
         // instead of all at once at the end.
         // The hope is that this will improve debugging, as we'll be able to see timings and partial output.
+        //
+        // We clear the env so that dynamic analysis strategies don't run.
+        // This is intended to make Broker more predictable: users aren't surprised by
+        // the presence or absence of build tools on their local system.
         let cmd = Command::new(&self.cli)
+            .env_clear()
             .current_dir(tmp.path())
             .arg_plain("analyze")
             .arg_plain("--debug")

--- a/src/fossa_cli.rs
+++ b/src/fossa_cli.rs
@@ -165,7 +165,7 @@ impl Location {
         // This is intended to make Broker more predictable: users aren't surprised by
         // the presence or absence of build tools on their local system.
         let cmd = Command::new(&self.cli)
-            .env_clear()
+            .env_remove("PATH")
             .current_dir(tmp.path())
             .arg_plain("analyze")
             .arg_plain("--debug")

--- a/tests/it/fossa_cli.rs
+++ b/tests/it/fossa_cli.rs
@@ -119,15 +119,10 @@ async fn analyze_fails_dynamic() {
         .expect_err("must fail to analyze");
 
     // Snapshot testing won't work here as the order of log lines output by FOSSA CLI are not determinstic.
-    // Just check for some specific substrings in the error output.
     let rendered = format!("{err:#}");
     assert!(
         rendered.contains("No analysis targets found in directory."),
-        "error: {rendered}"
-    );
-    assert!(
-        rendered.contains("Could not find executable: `cargo`."),
-        "error: {rendered}"
+        "{rendered}"
     );
 }
 

--- a/tests/it/fossa_cli.rs
+++ b/tests/it/fossa_cli.rs
@@ -80,7 +80,7 @@ async fn analyze_fails() {
         .await
         .expect("must download CLI");
 
-    // Scan our path taht does not exist.
+    // Scan our path that does not exist.
     println!("Analyzing '{}' with scan id '{scan_id}'", project.display());
     let err = location
         .analyze(&scan_id, &project)
@@ -94,6 +94,35 @@ async fn analyze_fails() {
         &ctx.data_root().to_string_lossy().to_string(),
         err
     );
+}
+
+/// Analysis of a dynamic-only project should fail, since dynamic strategies are disabled.
+/// Rust is dynamic only, so analyze Broker itself.
+#[tokio::test]
+async fn analyze_fails_dynamic() {
+    let (_tmp, config, ctx) = temp_config!(load);
+    let scan_id = Uuid::new_v4().to_string();
+
+    // Provide a path that doesn't exist, so that analysis fails.
+    let project = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    println!("Downloading CLI");
+    let location = fossa_cli::download(&ctx, config.debug().location(), DesiredVersion::Latest)
+        .await
+        .expect("must download CLI");
+
+    // Scan our project.
+    println!("Analyzing '{}' with scan id '{scan_id}'", project.display());
+    let err = location
+        .analyze(&scan_id, &project)
+        .await
+        .expect_err("must fail to analyze");
+
+    // Snapshot testing won't work here as the order of log lines output by FOSSA CLI are not determinstic.
+    // Just check for some specific substrings in the error output.
+    let rendered = format!("{err:#}");
+    assert!(rendered.contains("No analysis targets found in directory."));
+    assert!(rendered.contains("Could not find executable: `cargo`."));
 }
 
 #[tokio::test]

--- a/tests/it/fossa_cli.rs
+++ b/tests/it/fossa_cli.rs
@@ -121,8 +121,14 @@ async fn analyze_fails_dynamic() {
     // Snapshot testing won't work here as the order of log lines output by FOSSA CLI are not determinstic.
     // Just check for some specific substrings in the error output.
     let rendered = format!("{err:#}");
-    assert!(rendered.contains("No analysis targets found in directory."));
-    assert!(rendered.contains("Could not find executable: `cargo`."));
+    assert!(
+        rendered.contains("No analysis targets found in directory."),
+        "error: {rendered}"
+    );
+    assert!(
+        rendered.contains("Could not find executable: `cargo`."),
+        "error: {rendered}"
+    );
 }
 
 #[tokio::test]

--- a/tests/it/snapshots/it__fossa_cli__analyze_fails.snap
+++ b/tests/it/snapshots/it__fossa_cli__analyze_fails.snap
@@ -1,11 +1,11 @@
 ---
 source: tests/it/fossa_cli.rs
 expression: err
-info: /var/folders/q7/3nvvpy0d6js28m8lypw3tcx80000gn/T/.tmp6PIQd7
+info: /var/folders/q7/3nvvpy0d6js28m8lypw3tcx80000gn/T/.tmpUxvSC9
 ---
 run FOSSA CLI: {data root}/fossa
 args: ["analyze", "--debug", "--output", {file path}]
-env: []
+env: ["PATH=<REMOVED>"]
 status: 1
 stdout: ''
 stderr: '[DEBUG] Loading configuration file from "{config path}"


### PR DESCRIPTION
# Overview

Disables CLI dynamic analysis in Broker by clearing the env of the FOSSA CLI.

## Acceptance criteria

Users only get static analysis results.

## Testing plan

TODO

## Risks

None

## References

We decided on this in the initial design.

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
