### PR TITLE
Tracing tweaks

### DIFF
--- a/src/api/remote/git/repository.rs
+++ b/src/api/remote/git/repository.rs
@@ -433,7 +433,7 @@ fn git_ssh_command(path: &Path) -> Result<String, Report<Error>> {
 /// We only want the branches (which start with `refs/head/` and the tags (which start with `refs/tags`))
 /// Tags that end in ^{} should have the ^{} stripped from them. This will usually end up with a duplicate, so we
 /// de-dupe before returning
-#[tracing::instrument]
+#[tracing::instrument(skip_all)]
 fn parse_ls_remote(output: String) -> Vec<Reference> {
     output
         .split('\n')

--- a/src/api/remote/git/repository.rs
+++ b/src/api/remote/git/repository.rs
@@ -183,7 +183,7 @@ const DAYS_UNTIL_STALE: i64 = 30;
 /// To do this we need a cloned repository so that we can run
 /// `git log <some format string that includes that date of the commit> <branch_or_tag_name>`
 /// in the cloned repo for each branch or tag
-#[tracing::instrument(skip(transport))]
+#[tracing::instrument(skip_all)]
 async fn references_that_need_scanning(
     transport: &Transport,
     references: Vec<Reference>,

--- a/src/ext/secrecy.rs
+++ b/src/ext/secrecy.rs
@@ -51,7 +51,7 @@ impl ComparableSecretString {
 
 impl Debug for ComparableSecretString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("ComparableSecret({REDACTION_LITERAL})")
+        f.write_str(&format!("ComparableSecret({REDACTION_LITERAL})"))
     }
 }
 

--- a/src/fossa_cli.rs
+++ b/src/fossa_cli.rs
@@ -432,14 +432,13 @@ async fn check_command_existence(command_path: &PathBuf) -> bool {
         .unwrap_or(false)
 }
 
-/// command_name is "fossa.exe" on windows and "fossa" on all other platforms
-#[tracing::instrument]
+/// "fossa.exe" on windows and "fossa" on all other platforms
 #[cfg(target_family = "windows")]
 fn command_name() -> &'static str {
     "fossa.exe"
 }
 
-#[tracing::instrument]
+/// "fossa.exe" on windows and "fossa" on all other platforms
 #[cfg(target_family = "unix")]
 fn command_name() -> &'static str {
     "fossa"

--- a/src/subcommand/run.rs
+++ b/src/subcommand/run.rs
@@ -110,10 +110,10 @@ pub async fn main<D: Database>(ctx: &AppContext, config: Config, db: D) -> Resul
 
     // This function runs a bunch of async background tasks.
     // Create them all, then just `try_join!` on all of them at the end.
-    let healthcheck_worker = do_healthcheck(&ctx.db);
-    let integration_worker = do_poll_integrations(&ctx, scan_tx);
-    let scan_git_reference_worker = do_scan_git_references(&ctx, scan_rx, upload_tx);
-    let upload_worker = do_uploads(&ctx, upload_rx);
+    let healthcheck_worker = healthcheck(&ctx.db);
+    let integration_worker = poll_integrations(&ctx, scan_tx);
+    let scan_git_reference_worker = scan_git_references(&ctx, scan_rx, upload_tx);
+    let upload_worker = upload_scans(&ctx, upload_rx);
 
     // `try_join!` keeps all of the workers running until one of them fails,
     // at which point the failure is returned and remaining tasks are dropped.
@@ -130,7 +130,7 @@ pub async fn main<D: Database>(ctx: &AppContext, config: Config, db: D) -> Resul
 
 /// Conduct internal diagnostics to ensure Broker is still in a good state.
 #[tracing::instrument(skip_all)]
-async fn do_healthcheck<D: Database>(db: &D) -> Result<(), Error> {
+async fn healthcheck<D: Database>(db: &D) -> Result<(), Error> {
     for _ in 0.. {
         db.healthcheck()
             .await
@@ -175,7 +175,7 @@ struct UploadSourceUnits {
 
 /// Loops forever, polling configured integrations on their `poll_interval`.
 #[tracing::instrument(skip_all)]
-async fn do_poll_integrations<D: Database>(
+async fn poll_integrations<D: Database>(
     ctx: &CmdContext<D>,
     sender: Sender<ScanGitVCSReference>,
 ) -> Result<(), Error> {
@@ -185,16 +185,17 @@ async fn do_poll_integrations<D: Database>(
     // Each integration is configured with a poll interval.
     // Rather than have one big poll loop that has to track polling times for each integration,
     // just create a task per integration; they're cheap.
-    let integration_workers = ctx.config.integrations().iter().map(|integration| async {
-        do_poll_integration(&ctx.db, integration, sender.clone()).await
-    });
+    let integration_workers =
+        ctx.config.integrations().iter().map(|integration| async {
+            poll_integration(&ctx.db, integration, sender.clone()).await
+        });
 
     // Run all the workers in parallel. If one errors, return that error and drop the rest.
     try_join_all(integration_workers).await.discard_ok()
 }
 
 #[tracing::instrument(skip(db, sender))]
-async fn do_poll_integration<D: Database>(
+async fn poll_integration<D: Database>(
     db: &D,
     integration: &Integration,
     sender: Arc<Mutex<Sender<ScanGitVCSReference>>>,
@@ -305,7 +306,7 @@ async fn do_poll_integration<D: Database>(
 }
 
 #[tracing::instrument(skip_all)]
-async fn do_scan_git_references<D: Database>(
+async fn scan_git_references<D: Database>(
     ctx: &CmdContext<D>,
     mut receiver: Receiver<ScanGitVCSReference>,
     mut uploader: Sender<UploadSourceUnits>,
@@ -323,7 +324,7 @@ async fn do_scan_git_references<D: Database>(
         let guard = receiver.recv().await.change_context(Error::TaskReceive)?;
         let job = guard.item().change_context(Error::TaskReceive)?;
 
-        let upload = do_scan_git_reference(ctx, &job, &cli)
+        let upload = scan_git_reference(ctx, &job, &cli)
             .await
             .change_context(Error::TaskHandle)?;
 
@@ -337,7 +338,7 @@ async fn do_scan_git_references<D: Database>(
 }
 
 #[tracing::instrument(skip(_ctx, cli), fields(scan_id, cli_version))]
-async fn do_scan_git_reference<D: Database>(
+async fn scan_git_reference<D: Database>(
     _ctx: &CmdContext<D>,
     job: &ScanGitVCSReference,
     cli: &fossa_cli::Location,
@@ -373,7 +374,7 @@ async fn do_scan_git_reference<D: Database>(
 }
 
 #[tracing::instrument(skip_all)]
-async fn do_uploads<D: Database>(
+async fn upload_scans<D: Database>(
     ctx: &CmdContext<D>,
     mut receiver: Receiver<UploadSourceUnits>,
 ) -> Result<(), Error> {

--- a/src/subcommand/run.rs
+++ b/src/subcommand/run.rs
@@ -382,14 +382,14 @@ async fn upload_scans<D: Database>(
         let job = guard.item().change_context(Error::TaskReceive)?;
 
         let meta = ProjectMetadata::new(&job.integration, &job.reference);
-        info!("Uploading project: '{meta}'");
+        info!("Uploading scan for project: '{meta}'");
 
         let locator = fossa::upload_scan(ctx.config.fossa_api(), &meta, &job.cli, job.source_units)
             .await
             .change_context(Error::TaskHandle)?;
 
         debug!(scan_id = %job.scan_id, locator = %locator, "Uploaded scan");
-        info!("Uploaded project '{meta}' as locator: '{locator}'");
+        info!("Uploaded scan for project '{meta}' as locator: '{locator}'");
 
         guard.commit().change_context(Error::TaskComplete)?;
     }

--- a/src/subcommand/run.rs
+++ b/src/subcommand/run.rs
@@ -92,14 +92,13 @@ struct CmdContext<D> {
 }
 
 /// The primary entrypoint.
-#[tracing::instrument(skip_all, fields(subcommand = "run", cmd_context))]
+#[tracing::instrument(skip_all, fields(subcommand = "run"))]
 pub async fn main<D: Database>(ctx: &AppContext, config: Config, db: D) -> Result<(), Error> {
     let ctx = CmdContext {
         app: ctx.clone(),
         config,
         db,
     };
-    span_record!(cmd_context, debug ctx);
 
     let (scan_tx, scan_rx) = queue::open(&ctx.app, Queue::Scan)
         .await


### PR DESCRIPTION
# Overview

Trims down what we trace, in an effort to reduce duplication while still retaining the info.

At the end of the day we'll realistically always have _some_ duplication (we'd need to create an intelligent trace formatter that knows how to de-duplicate trace context; each function should log its own context) but this change is intended to reduce it.

Also massively trims down what is reported to the user.

## Acceptance criteria

Nothing concrete here; I basically just checked the tracing and output and think this makes more sense.

## Testing plan

I manually tested this.

## Risks

The primary risk here is that in the effort to not duplicate things we miss out tracing something important.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
