### PR TITLE
Retry fossa commands

### DIFF
--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -7,9 +7,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: curl https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
-      - run: fossa analyze
+
+      # Just try to run fossa up to twice, for the case of temporary network or service issues.
+      - run: fossa analyze || fossa analyze
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
-      - run: fossa test
+
+      # Just try to run fossa up to twice, for the case of temporary network or service issues.
+      - run: fossa test || fossa test
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
# Overview

I'm seeing failures like this fairly often, which is annoying: https://github.com/fossas/broker/actions/runs/4621344847/jobs/8172648834

This PR runs `fossa analyze` / `fossa test` up to twice, in an attempt to work around temporary issues.

Also filed a FOSSA CLI ticket: https://fossa.atlassian.net/browse/ANE-912

