### PR TITLE
Retry task queue operations

### DIFF
--- a/src/api/fossa.rs
+++ b/src/api/fossa.rs
@@ -300,7 +300,7 @@ pub async fn upload_scan(
     opts: &Config,
     project: &ProjectMetadata,
     cli: &CliMetadata,
-    source_units: SourceUnits,
+    source_units: &SourceUnits,
 ) -> Result<Locator, Error> {
     let url = opts.endpoint().join("api/builds/custom")?;
 
@@ -332,7 +332,7 @@ pub async fn upload_scan(
 
     run_request::<UploadResponse>(req)
         .await
-        .change_context_lazy(|| Error::upload_scan(&locator, &source_units))?
+        .change_context_lazy(|| Error::upload_scan(&locator, source_units))?
         .into()
 }
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -106,7 +106,7 @@ impl Config {
                 tracing_subscriber::fmt::layer()
                     .compact()
                     .with_file(false)
-                    .with_level(false)
+                    .with_level(true)
                     .with_line_number(false)
                     .with_target(false)
                     .with_writer(std::io::stderr)


### PR DESCRIPTION
# Overview

When running and setting up demos, I noted that intermittent issues (e.g. temporary FOSSA 503 errors) would cause jobs to fail, which would then fail out the entire Broker runtime.

We ideally need a job-level retry mechanism, but that's more complicated; [ticket here](https://fossa.atlassian.net/browse/ANE-932). Instead, here, we just manually use a `retry` function to retry the portions of `broker run` that aren't simply queue based operations.

_Note: this PR is not complete; I kind of am working on it ad-hoc if I get extra time._

## Acceptance criteria

Broker can recover from temporary issues.

## Testing plan

Unfortunately we don't have great tests here.

I set up [echotraffic](https://github.com/fossas/echotraffic) to proxy FOSSA. I then configured Broker to use it.
I then started running Broker, and killed the proxy. 
I noted that Broker successfully attempts to retry uploads instead of just dying.
I then restarted the proxy, and noted that uploads work again.

## Risks

This imposes more complexity in `broker run`.

## References

No ticket; observed during demos and was quick to fix.

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
