### PR TITLE
Linux fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 
+## v0.2.1
+
+Resolves a couple minor bugs:
+- Copy debug bundles instead of renaming them from the temp location.
+  This resolves issues preventing debug bundles from being stored for Linux installations where the temporary location
+  and the home folder are on separate mount points.
+- Locate `fossa` in `$PATH` before running it.
+  This resolves issues where some Linux implementations cannot execute commands without the full path.
+
+Additionally, Broker now reports to FOSSA that the build is being submitted by Broker instead of FOSSA CLI.
+Today FOSSA doesn't do anything with this information, but in the future we can use this to display
+projects that are imported by Broker with a different icon or different search parameters.
+
 ## v0.2.0
 
 Adds debug bundle generation to `broker fix`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
+ "which",
  "yaque",
  "zip",
 ]
@@ -3188,6 +3189,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aho-corasick 0.7.20",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ walkdir = "2.3.3"
 tar = "0.4.38"
 libflate = "1.3.0"
 typed-builder = "0.14.0"
+which = "4.4.0"
 
 [dev-dependencies]
 insta = { version = "1.29.0", features = ["filters", "json", "yaml"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "broker"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "The bridge between FOSSA and internal DevOps services"
 readme = "README.md"

--- a/src/api/fossa.rs
+++ b/src/api/fossa.rs
@@ -27,6 +27,13 @@ use crate::{
 
 use super::remote::{Integration, Reference};
 
+/// Specify that this upload came from Broker.
+///
+/// Currently Core doesn't do anything with this value but in the future we can use this
+/// to disambiguate Broker builds.
+const ANALYSIS_SOURCE_KEY: &str = "analysisSource";
+const ANALYSIS_SOURCE: &str = concat!("broker:", env!("CARGO_PKG_VERSION"));
+
 /// Errors encountered using this module.
 #[derive(Debug, Error)]
 pub enum Error {
@@ -343,6 +350,7 @@ pub async fn upload_scan(
         ("locator", locator.to_string()),
         ("cliVersion", cli.version.to_string()),
         ("managedBuild", String::from("true")),
+        (ANALYSIS_SOURCE_KEY, ANALYSIS_SOURCE.to_string()),
     ];
     if let Some(branch) = &project.branch {
         query.push(("branch", branch.to_string()));
@@ -390,7 +398,7 @@ impl Endpoint {
 }
 
 fn new_client() -> Result<Client, Error> {
-    static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
+    static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
     ClientBuilder::new()
         .user_agent(APP_USER_AGENT)
         .build()

--- a/src/fossa_cli.rs
+++ b/src/fossa_cli.rs
@@ -311,6 +311,13 @@ impl Location {
         // We're copying instead of moving because on Linux, it's likely these are at different mount points.
         let debug_bundle = tmp.path().join("fossa.debug.json.gz");
         let destination = self.artifacts.debug_bundle(scan_id);
+        if let Err(err) = fs::create_dir_all(self.artifacts.as_path()).await {
+            warn!(
+                "failed to create FOSSA CLI debug bundle location {:?}: {err:#}",
+                self.artifacts.as_path()
+            );
+        }
+
         match fs::copy(&debug_bundle, &destination).await {
             Ok(_) => debug!("stored FOSSA CLI debug bundle at {destination:?}"),
             Err(err) => {


### PR DESCRIPTION
# Overview

Resolves some issues seen when running on some Linux distributions/installations.

## Acceptance criteria

- Running Broker in a linux environment with separate mount points for temp and home works.
- Running Broker with a `$PATH`-available installation of `fossa` at the latest version works.

## Testing plan

I ran Broker successfully on an Arch install:
```
broker on  include-query-param [!] is 📦 v0.2.0 via 🦀 v1.69.0 
❯ cargo run -- run
   Compiling broker v0.2.1 (/home/jess/projects/broker)
    Finished dev [unoptimized + debuginfo] target(s) in 4.34s
     Running `target/debug/broker run`
2023-05-05T01:18:11.190563Z Debug artifacts being stored in '/home/jess/.config/fossa/broker/debugging/trace'
2023-05-05T01:18:11.194434Z Polling 'git:cloning via HTTP from https://github.com/replit/upm.git with no auth'
2023-05-05T01:18:11.593136Z Scanning 'git:cloning via HTTP from https://github.com/replit/upm.git with no auth' at 'git:branch:test@d38ad271a372f52bcb2809d615de55f139a3481d'
2023-05-05T01:18:13.809090Z Enqueued task to scan 'git:cloning via HTTP from https://github.com/replit/upm.git with no auth' at 'git:branch:main@5ed1311620980b0926efaa46bcfdfb36db1f03e9'
2023-05-05T01:18:13.809148Z Enqueued task to scan 'git:cloning via HTTP from https://github.com/replit/upm.git with no auth' at 'git:branch:test@d38ad271a372f52bcb2809d615de55f139a3481d'
2023-05-05T01:18:13.809181Z Next poll interval for 'git:cloning via HTTP from https://github.com/replit/upm.git with no auth' in 3600s
2023-05-05T01:18:14.348578Z Scanned 'git:cloning via HTTP from https://github.com/replit/upm.git with no auth' at 'git:branch:test@d38ad271a372f52bcb2809d615de55f139a3481d'
2023-05-05T01:18:14.351245Z Scanning 'git:cloning via HTTP from https://github.com/replit/upm.git with no auth' at 'git:branch:main@5ed1311620980b0926efaa46bcfdfb36db1f03e9'
2023-05-05T01:18:14.352792Z Uploading scan for project: 'https://github.com/replit/upm.git@d38ad271a372f52bcb2809d615de55f139a3481d (test)'
2023-05-05T01:18:14.641978Z Uploaded scan for project 'https://github.com/replit/upm.git@d38ad271a372f52bcb2809d615de55f139a3481d (test)' as locator: 'custom+24357/github.com/replit/upm$d38ad271a372f52bcb2809d615de55f139a3481d'
```

I also ran all tests on this system and it worked fine:
```
broker on  include-query-param [!] is 📦 v0.2.1 via 🦀 v1.69.0 took 10s 
❯ cargo nextest run                                                   
   Compiling broker v0.2.1 (/home/jess/projects/broker)
    Finished test [unoptimized + debuginfo] target(s) in 3.96s
    Starting 68 tests across 3 binaries
    <snip for brevity>
------------
     Summary [   4.695s] 68 tests run: 68 passed, 0 skipped
```

## Risks

None

## References

None

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
