### PR TITLE
Fix bundle creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Don't include any debug bundle generated during a run of Broker or FOSSA CLI.
+fossa.broker.debug.tar.gz
+fossa.debug.json.gz
+
 # Node isn't used for this actual project, but we have a node test fixture
 # to make tests run faster.
 node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 
+## v0.2.2
+
+Bug fix: 
+
+- Broker now copies its debug bundle (generated during `broker fix`) from the system temp location instead of renaming.
+  This resolves issues preventing debug bundles from being stored for Linux installations where the temporary location
+  and the home folder are on separate mount points.
+
 ## v0.2.1
 
 Features:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aho-corasick 0.7.20",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "broker"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "The bridge between FOSSA and internal DevOps services"
 readme = "README.md"


### PR DESCRIPTION
# Overview

Broker debug bundles are now able to persist across mount points.
Similar fix to #80, I just didn't think to persist this fix here. I've checked for other uses of `persist` or `rename` in the codebase and found none.

## Acceptance criteria

Users on systems where the temp file location is on a different mount point can now generate debug bundles.

## Testing plan

This unfortunately isn't really testable in automated testing, but I did test it on my Arch system:
```
jess in 🌐 grace in broker on  fix-bundle-creation [!] is 📦 v0.2.2 via 🦀 v1.69.0 took 3s
❯ cargo run -- fix --export-bundle
   Compiling broker v0.2.2 (/home/jess/projects/broker)
    Finished dev [unoptimized + debuginfo] target(s) in 3.22s
     Running `target/debug/broker fix --export-bundle`
2023-06-12T19:22:09.442973Z Debug artifacts being stored in '/home/jess/.config/fossa/broker/debugging/trace'

Diagnosing connections to configured repositories

✅ https://github.com/replit/upm.git

Diagnosing connection to FOSSA

✅ check fossa API connection with no auth required
✅ check fossa API connection with auth required

Collecting debug bundle

✅ Collected debug bundle at 'fossa.broker.debug.tar.gz'
Please include this debug bundle in any request to FOSSA Support.

jess in 🌐 grace in broker on  fix-bundle-creation [!?] is 📦 v0.2.2 via 🦀 v1.69.0
❯ ll | grep debug
.rw------- 1.2M 12 Jun 12:22 -I fossa.broker.debug.tar.gz
```

## Risks

No real risk; this temporarily causes the hard disk to require 2x debug bundle size but that shouldn't be an issue for any of our users.

## References

https://teamfossa.slack.com/archives/C04UBSBT822/p1685637742066709?thread_ts=1685637725.732069&cid=C04UBSBT822

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
