### PR TITLE
Clarify some `Display` impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.2.2"
+version = "0.2.3-pre"
 dependencies = [
  "aho-corasick 0.7.20",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "broker"
-version = "0.2.2"
+version = "0.2.3-pre"
 edition = "2021"
 description = "The bridge between FOSSA and internal DevOps services"
 readme = "README.md"

--- a/src/api/remote.rs
+++ b/src/api/remote.rs
@@ -164,7 +164,7 @@ pub enum Protocol {
 impl Display for Protocol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Protocol::Git(transport) => write!(f, "git:{transport}"),
+            Protocol::Git(transport) => write!(f, "git::{transport}"),
         }
     }
 }
@@ -238,7 +238,7 @@ impl Reference {
 impl Display for Reference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Reference::Git(reference) => write!(f, "git:{reference}"),
+            Reference::Git(reference) => write!(f, "git::{reference}"),
         }
     }
 }

--- a/src/api/remote/git.rs
+++ b/src/api/remote/git.rs
@@ -30,10 +30,10 @@ impl Display for Reference {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Reference::Branch { name, head } => {
-                write!(f, "branch:{name}@{head}")
+                write!(f, "branch::{name}@{head}")
             }
             Reference::Tag { name, commit } => {
-                write!(f, "tag:{name}@{commit}")
+                write!(f, "tag::{name}@{commit}")
             }
         }
     }

--- a/src/api/remote/git/transport.rs
+++ b/src/api/remote/git/transport.rs
@@ -48,12 +48,11 @@ impl Display for Transport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Transport::Ssh { endpoint, .. } => {
-                write!(f, "ssh:{endpoint}")
+                write!(f, "ssh::{endpoint}")
             }
-            Transport::Http { endpoint, auth } => match auth {
-                Some(_) => write!(f, "http:{endpoint} with auth"),
-                None => write!(f, "cloning via HTTP from {endpoint} with no auth"),
-            },
+            Transport::Http { endpoint, .. } => {
+                write!(f, "http::{endpoint}")
+            }
         }
     }
 }


### PR DESCRIPTION
# Overview

The `Display` impls for integrations look awkward in logs:
```
No changes to 'git:http:https://some-address/org/repo with auth'
```

This PR tweaks these to more clearly delineate "identifiers" from "things inside the string", as well as removing the "with auth" trailer:
```
No changes to 'git::http::https://some-address/org/repo'
```


