### PR TITLE
Document customizing the temporary location

### DIFF
--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -21,6 +21,17 @@ to make relative file paths clear.
 Most Broker subcommands allow customizing the data root via the `-r` flag.
 For more information on this and other runtime customization, run `broker -h`.
 
+### Can I customize the temporary directory used by Broker?
+
+- On Linux and macOS: set the `$TMPDIR` environment variable.
+- On Windows: Broker uses the `GetTempPath` system call,
+  [which checks for the existence of environment variables in the following order](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppath2a#remarks)
+  and uses the first path found:
+  - The path specified by the `TMP` environment variable.
+  - The path specified by the `TEMP` environment variable.
+  - The path specified by the `USERPROFILE` environment variable.
+  - The Windows directory.
+
 ### Where is the config file stored?
 
 - On macOS and Linux, the config is stored at `$DATA_ROOT/config.yml`.


### PR DESCRIPTION
# Overview

Adds documentation for how to customize the temporary location for Broker.
This mirrors, then adds more context, to what we already report here: https://github.com/fossas/broker/blob/a1eb9d629e99abfa89ddb9aaf0a4e55ec2721a3e/src/api/remote/git/repository.rs#L316