### PR TITLE
Ane 643 broker config

### DIFF
--- a/src/config/file/v1.rs
+++ b/src/config/file/v1.rs
@@ -40,6 +40,7 @@ pub fn load(content: String) -> Result<super::Config, Report<Error>> {
 /// Unlike `RawRunArgs`, we don't have to leak this to consumers of the `config` module,
 /// so we don't.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawConfigV1 {
     #[serde(rename = "fossa_endpoint")]
     endpoint: String,
@@ -51,6 +52,9 @@ struct RawConfigV1 {
     integrations: Vec<Integration>,
 
     debugging: Debugging,
+
+    #[allow(dead_code)]
+    version: usize,
 }
 
 impl RawConfigV1 {
@@ -77,6 +81,7 @@ fn validate(config: RawConfigV1) -> Result<super::Config, Report<Error>> {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(super) struct Debugging {
     location: PathBuf,
 
@@ -95,6 +100,7 @@ impl TryFrom<Debugging> for debug::Config {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(super) struct DebuggingRetention {
     days: usize,
 }
@@ -120,7 +126,7 @@ impl TryFrom<DebuggingRetention> for debug::Retention {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "type")]
+#[serde(tag = "type", deny_unknown_fields)]
 pub(super) enum Integration {
     #[serde(rename = "git")]
     Git {
@@ -192,7 +198,7 @@ impl TryFrom<Integration> for remote::Integration {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(tag = "type")]
+#[serde(tag = "type", deny_unknown_fields)]
 pub(super) enum Auth {
     #[serde(rename = "ssh_key_file")]
     SshKeyFile { path: PathBuf },

--- a/src/config/file/v1.rs
+++ b/src/config/file/v1.rs
@@ -53,8 +53,8 @@ struct RawConfigV1 {
 
     debugging: Debugging,
 
-    #[allow(dead_code)]
-    version: usize,
+    #[serde(rename(deserialize = "version"))]
+    _version: usize,
 }
 
 impl RawConfigV1 {

--- a/testdata/config/basic-http-basic-malformed-auth.yml
+++ b/testdata/config/basic-http-basic-malformed-auth.yml
@@ -1,0 +1,19 @@
+fossa_endpoint: https://app.fossa.com
+fossa_integration_key: abcd1234
+version: 1
+
+debugging:
+  location: /home/me/.config/fossa/broker/debugging/
+  retention:
+    days: 3
+
+integrations:
+  - type: git
+    poll_interval: 1h
+    remote: https://github.com/fossas/broker.git
+    auth:
+      type: http_basic
+      username: jssblck
+      password: efgh5678
+      team: team
+      title: title

--- a/testdata/config/basic-http-basic-malformed-debugging.yml
+++ b/testdata/config/basic-http-basic-malformed-debugging.yml
@@ -1,0 +1,18 @@
+fossa_endpoint: https://app.fossa.com
+fossa_integration_key: abcd1234
+version: 1
+
+debugging:
+  location: /home/me/.config/fossa/broker/debugging/
+  team: malformed
+  retention:
+    days: 3
+
+integrations:
+  - type: git
+    poll_interval: 1h
+    remote: https://github.com/fossas/broker.git
+    auth:
+      type: http_basic
+      username: jssblck
+      password: efgh5678

--- a/testdata/config/basic-retention-malformed.yml
+++ b/testdata/config/basic-retention-malformed.yml
@@ -5,4 +5,3 @@ version: 1
 debugging:
   location: /home/me/.fossa/broker/debugging/
   retention:
-    some_other_key: 3

--- a/testdata/config/private-repo-http-no-auth.yml
+++ b/testdata/config/private-repo-http-no-auth.yml
@@ -6,7 +6,6 @@ debugging:
   location: /home/me/.config/fossa/broker/debugging/
   retention:
     days: 7
-    size: 1048576
 
 integrations:
   - type: git

--- a/tests/it/config.rs
+++ b/tests/it/config.rs
@@ -135,6 +135,26 @@ async fn test_integration_git_http_basic() {
 }
 
 #[tokio::test]
+async fn test_integration_git_http_basic_malformed_auth() {
+    let (config_file_path, err) = load_config_err!(
+        "testdata/config/basic-http-basic-malformed-auth.yml",
+        "testdata/database/empty.sqlite"
+    )
+    .await;
+    assert_error_stack_snapshot!(&config_file_path, err);
+}
+
+#[tokio::test]
+async fn test_integration_git_http_basic_malformed_debugging() {
+    let (config_file_path, err) = load_config_err!(
+        "testdata/config/basic-http-basic-malformed-debugging.yml",
+        "testdata/database/empty.sqlite"
+    )
+    .await;
+    assert_error_stack_snapshot!(&config_file_path, err);
+}
+
+#[tokio::test]
 async fn test_integration_git_http_header() {
     let (_, conf) = load_config!(
         "testdata/config/basic-http-header.yml",

--- a/tests/it/fix.rs
+++ b/tests/it/fix.rs
@@ -134,5 +134,4 @@ async fn generates_debug_bundle() {
 
     let unpacked = expand_debug_bundle(bundle.location());
     assert_equal_contents("testdata/fossa.broker.debug/bundled", unpacked.path());
-    
 }

--- a/tests/it/fix.rs
+++ b/tests/it/fix.rs
@@ -56,7 +56,6 @@ fn fix_output_filters() -> Vec<(&'static str, &'static str)> {
 #[tokio::test]
 async fn with_successful_http_no_auth_integration() {
     guard_integration_test!();
-
     set_snapshot_vars!();
     let (_, conf) = load_config!(
         "testdata/config/basic-http-no-auth.yml",
@@ -79,7 +78,6 @@ async fn with_successful_http_no_auth_integration() {
 #[tokio::test]
 async fn with_failing_http_basic_auth_integration() {
     guard_integration_test!();
-
     set_snapshot_vars!();
     let (_, conf) = load_config!(
         "testdata/config/basic-http-basic-bad-repo-name.yml",
@@ -136,4 +134,5 @@ async fn generates_debug_bundle() {
 
     let unpacked = expand_debug_bundle(bundle.location());
     assert_equal_contents("testdata/fossa.broker.debug/bundled", unpacked.path());
+    
 }

--- a/tests/it/fix.rs
+++ b/tests/it/fix.rs
@@ -56,6 +56,7 @@ fn fix_output_filters() -> Vec<(&'static str, &'static str)> {
 #[tokio::test]
 async fn with_successful_http_no_auth_integration() {
     guard_integration_test!();
+
     set_snapshot_vars!();
     let (_, conf) = load_config!(
         "testdata/config/basic-http-no-auth.yml",
@@ -78,6 +79,7 @@ async fn with_successful_http_no_auth_integration() {
 #[tokio::test]
 async fn with_failing_http_basic_auth_integration() {
     guard_integration_test!();
+
     set_snapshot_vars!();
     let (_, conf) = load_config!(
         "testdata/config/basic-http-basic-bad-repo-name.yml",
@@ -99,12 +101,14 @@ async fn with_failing_http_basic_auth_integration() {
 #[tokio::test]
 async fn with_failing_http_no_auth_integration() {
     guard_integration_test!();
+
     set_snapshot_vars!();
     let (_, conf) = load_config!(
         "testdata/config/private-repo-http-no-auth.yml",
         "testdata/database/empty.sqlite"
     )
     .await;
+
     let logger = TestLogger::new();
     broker::cmd::fix::main(&conf, &logger, BundleExport::Disable)
         .await

--- a/tests/it/fix.rs
+++ b/tests/it/fix.rs
@@ -101,14 +101,12 @@ async fn with_failing_http_basic_auth_integration() {
 #[tokio::test]
 async fn with_failing_http_no_auth_integration() {
     guard_integration_test!();
-
     set_snapshot_vars!();
     let (_, conf) = load_config!(
         "testdata/config/private-repo-http-no-auth.yml",
         "testdata/database/empty.sqlite"
     )
     .await;
-
     let logger = TestLogger::new();
     broker::cmd::fix::main(&conf, &logger, BundleExport::Disable)
         .await

--- a/tests/it/snapshots/it__config__integration_git_http_basic_malformed_auth.snap
+++ b/tests/it/snapshots/it__config__integration_git_http_basic_malformed_auth.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/it/config.rs
 expression: err
-info: testdata/config/basic-retention-malformed.yml
+info: testdata/config/basic-http-basic-malformed-auth.yml
 ---
 load config file
 ├╴at {source location}
@@ -12,5 +12,5 @@ load config file
 ├─▶ parse config file
 │   ╰╴at {source location}
 │
-╰─▶ debugging.retention: missing field `days` at line 7 column 13
+╰─▶ integrations: unknown field `team`, expected `username` or `password` at line 11 column 3
     ╰╴at {source location}

--- a/tests/it/snapshots/it__config__integration_git_http_basic_malformed_debugging.snap
+++ b/tests/it/snapshots/it__config__integration_git_http_basic_malformed_debugging.snap
@@ -1,7 +1,7 @@
 ---
 source: tests/it/config.rs
 expression: err
-info: testdata/config/basic-retention-malformed.yml
+info: testdata/config/basic-http-basic-malformed-debugging.yml
 ---
 load config file
 ├╴at {source location}
@@ -12,5 +12,5 @@ load config file
 ├─▶ parse config file
 │   ╰╴at {source location}
 │
-╰─▶ debugging.retention: missing field `days` at line 7 column 13
+╰─▶ debugging: unknown field `team`, expected `location` or `retention` at line 7 column 3
     ╰╴at {source location}


### PR DESCRIPTION
# Overview

Unknown fields in the config were being ignored and led to confusion. 
e.g. Team and Title fields were passed in auth as opposed to integration
```

integrations:
  - type: git
    poll_interval: 1h
    remote: https://some-remote/some-project.git
    auth:
      team: some_team
      title: some_title
```


## Acceptance criteria

Broker should strictly parse the config file and throw errors to detect these issues

## Testing plan

1.  test_integration_git_http_basic_malformed_auth - Test unknown fields in auth section to mimic what we saw in the ticket
2.  test_integration_git_http_basic_malformed_debugging - Another test to detect unknown fields in debugging level 

## Risks
1. 
Removed 'some_other_key' field in testdata/config/basic-retention-malformed.yml. 
```
debugging:
  location: /home/me/.fossa/broker/debugging/
  retention:
    some_other_key: 3
```
With the added checks for unknown fields it would throw an error that the field is unknown. Although this is correct, this was not the original intention of the test. The test intended to check if the field 'days' was populated. Due to this, I opted to removing the 'some_other_key' field to restore the test's previous intent. 



2.
Added the following to RawConfigV1 struct: 
```
    #[allow(dead_code)]
    version: usize,
```
Without adding this field there would be deserialization errors on the version field in our tests due to [serde(deny_unknown_fields)]. I added the field to allow the parsing of the 'version' field as we know that it will always be provided in this case.

#[allow(dead_code)] is added to account for the fact that we are never reading the version field, otherwise a warning will be thrown


Reasons for not using #[serde(skip_deserialization, default = 1)] on the new version field
Using skip_deserialization alone will cause errors due to the 'unknown' version field. It needs to be supplemented with a default. In the above example you cannot use the actual default value, instead you need to pass in the name of the default function (string) that sets the default value. I found that doing so would be convoluted and unnecessary as we can just allow it to parse the config for 'version' as it is low cost. From there we can just opt not to read the data



## References

[ANE-1031](https://fossa.atlassian.net/browse/ANE-1031)

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).


[ANE-1031]: https://fossa.atlassian.net/browse/ANE-1031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ