### PR TITLE
Rust 1.72 clippy and format

### DIFF
--- a/src/config/args.rs
+++ b/src/config/args.rs
@@ -367,7 +367,7 @@ impl From<String> for DatabaseFilePath {
 
 fn discovery_enabled() -> bool {
     std::env::var(DISABLE_FILE_DISCOVERY_VAR)
-        .map(|value| vec!["true", "1"].contains(&value.as_str()))
+        .map(|value| ["true", "1"].contains(&value.as_str()))
         .map(|value| !value)
         .unwrap_or(true)
 }

--- a/src/ext/io.rs
+++ b/src/ext/io.rs
@@ -94,7 +94,9 @@ pub async fn tempfile() -> Result<File, Report<Error>> {
 /// If the destination parent directory doesn't exist, it is created automatically.
 #[tracing::instrument]
 pub async fn rename(src: &Path, dst: &Path) -> Result<(), Report<Error>> {
-    let Some(parent) = dst.parent() else { return report!(Error::CreateParentDir(dst.to_path_buf())).wrap_err() };
+    let Some(parent) = dst.parent() else {
+        return report!(Error::CreateParentDir(dst.to_path_buf())).wrap_err();
+    };
     tokio::fs::create_dir_all(parent)
         .await
         .context_lazy(|| Error::CreateParentDir(dst.to_path_buf()))?;

--- a/src/fossa_cli.rs
+++ b/src/fossa_cli.rs
@@ -364,7 +364,7 @@ pub async fn find_or_download(
 
     // If the CLI isn't already local, download it.
     let Some(current_path) = current_path else {
-        return download(ctx, artifact_root, desired_version).await
+        return download(ctx, artifact_root, desired_version).await;
     };
 
     // Now we know the CLI exists locally, check if it matches the desired version.

--- a/tests/it/args.rs
+++ b/tests/it/args.rs
@@ -70,7 +70,7 @@ async fn infers_db_path_failing_config() {
 }
 
 #[proptest]
-fn fossa_api_endpoint(#[strategy(r#"\PC+"#)] user_input: String) {
+fn fossa_api_endpoint(#[strategy(r"\PC+")] user_input: String) {
     let canonical = Url::parse(&user_input);
     let validated = Endpoint::try_from(user_input.clone());
 
@@ -109,7 +109,7 @@ fn fossa_api_endpoint(#[strategy(r#"\PC+"#)] user_input: String) {
 }
 
 #[proptest]
-fn fossa_api_key(#[strategy(r#"\PC+"#)] user_input: String) {
+fn fossa_api_key(#[strategy(r"\PC+")] user_input: String) {
     match Key::try_from(user_input.clone()) {
         Ok(validated) => prop_assert_eq!(validated.expose_secret(), &user_input),
         Err(err) => prop_assert!(false, "unexpected parse error: {:#}", err),

--- a/tests/it/config.rs
+++ b/tests/it/config.rs
@@ -70,24 +70,36 @@ async fn test_one_integration() {
     let (_, conf) = load_config!().await;
 
     let mut integrations = conf.integrations().as_ref().iter();
-    let Some(_) = integrations.next() else { panic!("must have parsed at least one integration") };
-    let None = integrations.next() else { panic!("must have parsed exactly one integration") };
+    let Some(_) = integrations.next() else {
+        panic!("must have parsed at least one integration")
+    };
+    let None = integrations.next() else {
+        panic!("must have parsed exactly one integration")
+    };
 }
 
 #[tokio::test]
 async fn test_integration_git_ssh_key_file() {
     let (_, conf) = load_config!().await;
 
-    let Some(integration) = conf.integrations().as_ref().iter().next() else { panic!("must have parsed at least one integration") };
+    let Some(integration) = conf.integrations().as_ref().iter().next() else {
+        panic!("must have parsed at least one integration")
+    };
     assert_eq!(integration.poll_interval(), gen::code_poll_interval("1h"));
 
-    let remote::Protocol::Git(remote::git::transport::Transport::Ssh{ endpoint, auth }) = integration.protocol() else { panic!("must have parsed integration to git") };
+    let remote::Protocol::Git(remote::git::transport::Transport::Ssh { endpoint, auth }) =
+        integration.protocol()
+    else {
+        panic!("must have parsed integration to git")
+    };
     assert_eq!(
         endpoint,
         &gen::code_remote("git@github.com:fossas/broker.git")
     );
 
-    let api::ssh::Auth::KeyFile(file) = auth else { panic!("must have parsed ssh key file auth") };
+    let api::ssh::Auth::KeyFile(file) = auth else {
+        panic!("must have parsed ssh key file auth")
+    };
     assert_eq!(file, &gen::path_buf("/home/me/.ssh/id_rsa"));
 }
 
@@ -99,16 +111,24 @@ async fn test_integration_git_ssh_key() {
     )
     .await;
 
-    let Some(integration) = conf.integrations().as_ref().iter().next() else { panic!("must have parsed at least one integration") };
+    let Some(integration) = conf.integrations().as_ref().iter().next() else {
+        panic!("must have parsed at least one integration")
+    };
     assert_eq!(integration.poll_interval(), gen::code_poll_interval("1h"));
 
-    let remote::Protocol::Git(remote::git::transport::Transport::Ssh{ endpoint, auth }) = integration.protocol() else { panic!("must have parsed integration") };
+    let remote::Protocol::Git(remote::git::transport::Transport::Ssh { endpoint, auth }) =
+        integration.protocol()
+    else {
+        panic!("must have parsed integration")
+    };
     assert_eq!(
         endpoint,
         &gen::code_remote("git@github.com:fossas/broker.git")
     );
 
-    let api::ssh::Auth::KeyValue(key) = auth else { panic!("must have parsed auth value") };
+    let api::ssh::Auth::KeyValue(key) = auth else {
+        panic!("must have parsed auth value")
+    };
     assert_eq!(key, &gen::secret("efgh5678"));
 }
 
@@ -120,16 +140,24 @@ async fn test_integration_git_http_basic() {
     )
     .await;
 
-    let Some(integration) = conf.integrations().as_ref().iter().next() else { panic!("must have parsed at least one integration") };
+    let Some(integration) = conf.integrations().as_ref().iter().next() else {
+        panic!("must have parsed at least one integration")
+    };
     assert_eq!(integration.poll_interval(), gen::code_poll_interval("1h"));
 
-    let remote::Protocol::Git(remote::git::transport::Transport::Http{ endpoint, auth }) = integration.protocol() else { panic!("must have parsed integration") };
+    let remote::Protocol::Git(remote::git::transport::Transport::Http { endpoint, auth }) =
+        integration.protocol()
+    else {
+        panic!("must have parsed integration")
+    };
     assert_eq!(
         endpoint,
         &gen::code_remote("https://github.com/fossas/broker.git")
     );
 
-    let Some(api::http::Auth::Basic { username, password }) = auth else { panic!("must have parsed auth value") };
+    let Some(api::http::Auth::Basic { username, password }) = auth else {
+        panic!("must have parsed auth value")
+    };
     assert_eq!(username, &String::from("jssblck"));
     assert_eq!(password, &gen::secret("efgh5678"));
 }
@@ -162,7 +190,9 @@ async fn test_integration_git_http_header() {
     )
     .await;
 
-    let Some(integration) = conf.integrations().as_ref().iter().next() else { panic!("must have parsed at least one integration") };
+    let Some(integration) = conf.integrations().as_ref().iter().next() else {
+        panic!("must have parsed at least one integration")
+    };
     assert_eq!(integration.poll_interval(), gen::code_poll_interval("1h"));
 }
 
@@ -174,16 +204,24 @@ async fn test_integration_git_http_no_auth() {
     )
     .await;
 
-    let Some(integration) = conf.integrations().as_ref().iter().next() else { panic!("must have parsed at least one integration") };
+    let Some(integration) = conf.integrations().as_ref().iter().next() else {
+        panic!("must have parsed at least one integration")
+    };
     assert_eq!(integration.poll_interval(), gen::code_poll_interval("1h"));
 
-    let remote::Protocol::Git(remote::git::transport::Transport::Http{ endpoint, auth }) = integration.protocol() else { panic!("must have parsed integration") };
+    let remote::Protocol::Git(remote::git::transport::Transport::Http { endpoint, auth }) =
+        integration.protocol()
+    else {
+        panic!("must have parsed integration")
+    };
     assert_eq!(
         endpoint,
         &gen::code_remote("https://github.com/fossas/broker.git")
     );
 
-    let None = auth else { panic!("must have parsed no auth value") };
+    let None = auth else {
+        panic!("must have parsed no auth value")
+    };
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Overview

A dependabot PR was failing due to updates to Clippy and `cargo fmt` in Rust 1.72.0. (To be precise, it was 1.71.1 in the dependabot PR, but 1.72.0 got released a few hours ago, so I just upgraded to that)

https://github.com/fossas/broker/pull/122

This PR just fixes those problems.

## Acceptance criteria

The linters pass

## Testing plan


## Risks

None

## References



## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
