### PR TITLE
run cargo machete in CI and fail if there are unused deps

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -46,3 +46,26 @@ jobs:
       with:
         tool: sqlx-cli
     - run: '! make migration-status | grep -q pending'
+
+  # Ensure all deps are used
+  unused-deps:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+
+    - uses: Swatinem/rust-cache@v2
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-machete
+
+    # If you're here because CI is flagging a dependency as unused,
+    # but it really is used, you can add an exception!
+    #
+    # https://github.com/bnjbvr/cargo-machete#false-positives
+    - run: cargo machete

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -68,4 +68,9 @@ jobs:
     # but it really is used, you can add an exception!
     #
     # https://github.com/bnjbvr/cargo-machete#false-positives
+    #
+    # If it is unused, you can fix it by installing and running machete:
+    #
+    # cargo binstall cargo-machete
+    # cargo machete --fix
     - run: cargo machete

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,6 @@ dependencies = [
  "derive-new",
  "derive_more",
  "dirs",
- "duplicate",
  "error-stack",
  "futures",
  "getset",
@@ -313,7 +312,6 @@ dependencies = [
  "uuid",
  "walkdir",
  "which",
- "yaque",
  "zip",
 ]
 
@@ -919,16 +917,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "duplicate"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de78e66ac9061e030587b2a2e75cc88f22304913c907b11307bca737141230cb"
-dependencies = [
- "heck",
- "proc-macro-error",
-]
-
-[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,15 +1049,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1485,26 +1464,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f2cb48b81b1dc9f39676bf99f5499babfec7cd8fe14307f7b3d747208fb5690"
 
 [[package]]
-name = "inotify"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
-dependencies = [
- "bitflags 1.3.2",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,26 +1556,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "kqueue"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8fc60ba15bf51257aa9807a48a61013db043fcf3a78cb0d916e8e396dcad98"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
 ]
 
 [[package]]
@@ -1814,33 +1753,6 @@ name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
-
-[[package]]
-name = "notify"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ea850aa68a06e48fdb069c0ec44d0d64c8dbffa49bf3b6f7f0a901fdea1ba9"
-dependencies = [
- "bitflags 1.3.2",
- "crossbeam-channel",
- "filetime",
- "fsevent-sys",
- "inotify",
- "kqueue",
- "libc",
- "mio",
- "walkdir",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2889,20 +2801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71eb43e528fdc239f08717ec2a378fdb017dddbc3412de15fff527554591a66c"
-dependencies = [
- "cfg-if",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "winapi",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3778,21 +3676,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
-]
-
-[[package]]
-name = "yaque"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c5ad0137247948f89dfd6da0bbd8ee16c67b57e4f9dc1b1e1ed297fc1d568c"
-dependencies = [
- "futures",
- "lazy_static",
- "log",
- "notify",
- "rand",
- "semver",
- "sysinfo",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ url = "2.4.0"
 base64 = "0.21.2"
 itertools = "0.10.5"
 time = { version = "0.3.22", features = ["parsing"] }
-yaque = "0.6.4"
 reqwest = { version = "0.11.18", features = ["rustls-tls"], default-features = false }
 zip = "0.6.6"
 bytes = "1.4.0"
@@ -59,7 +58,6 @@ atty = "0.2.14"
 serde_json = "1.0.96"
 cached = "0.43.0"
 tracing-test = { version = "0.2.4", features = ["no-env-filter"] }
-duplicate = "1.0.0"
 aho-corasick = "0.7.20"
 regex = "1.9.3"
 srclib = { git = "https://github.com/fossas/foundation-libs" }


### PR DESCRIPTION
# Overview

We have two unused deps. This PR removes those unused deps and also runs [`cargo machete`](https://github.com/bnjbvr/cargo-machete) to ensure that we find and remove unused deps.

## Acceptance criteria

- We should be alerted to unused deps and have to remove them in order to get CI to pass
- There should be no more unused deps

## Testing plan

- The new CI should fail before fixing unused deps — See https://github.com/fossas/broker/actions/runs/6113155454/job/16592087556?pr=131
- The new CI should pass after fixing unused deps

## Risks

None

## References


## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
