### PR TITLE
Increase DAYS_UNTIL_STALE from 30 to 180

### DIFF
--- a/src/api/remote/git/repository.rs
+++ b/src/api/remote/git/repository.rs
@@ -181,8 +181,8 @@ pub fn pastable_ls_remote_command(transport: &Transport) -> Result<String, Repor
     pastable_git_command(transport, &ls_remote_args(transport), None)
 }
 
-// Days until a commit is considered stale and will not be scanned
-const DAYS_UNTIL_STALE: i64 = 30;
+// Days until a commit is considered stale and will not be scanned (was 30, now 180 by customer request)
+const DAYS_UNTIL_STALE: i64 = 180;
 
 /// Get a list of all branches and tags for the given integration
 /// This is done by doing this:


### PR DESCRIPTION
# Overview

Per Jay at Mars, the broker will not import a Repo that has not been updated in the last 30 days regardless of its representation status in Fossa. This changes the number of days until a commit is considered stale to 180.

## Acceptance criteria

Users should now be able to import commits up to 180 days old into the broker.

## Testing plan

n/a

## Risks

Are there any other areas where a commit older than 30 days could cause an issue?

## References

https://fossa.zendesk.com/agent/tickets/7174

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
