### PR TITLE
[ANE-1027] Reduce broker trace file size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.3.2
+
+Features:
+- Simplify trace output to reduce trace file size
+
 ## v0.3.1
 
 Features:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aho-corasick 0.7.20",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "broker"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "The bridge between FOSSA and internal DevOps services"
 readme = "README.md"

--- a/src/api/remote/git/repository.rs
+++ b/src/api/remote/git/repository.rs
@@ -342,7 +342,6 @@ fn parse_ls_remote(output: String) -> Vec<Reference> {
         .collect()
 }
 
-#[tracing::instrument]
 fn line_to_git_ref(line: &str) -> Option<Reference> {
     let mut parsed = line.split_whitespace();
     let commit = parsed.next()?;

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -141,9 +141,7 @@ impl Config {
                 tracing_subscriber::fmt::layer()
                     .json()
                     .flatten_event(true)
-                    .with_thread_ids(true)
-                    .with_span_list(false)
-                    .with_span_events(FmtSpan::ACTIVE)
+                    .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
                     .with_writer(sink),
             );
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -140,7 +140,10 @@ impl Config {
             .with(
                 tracing_subscriber::fmt::layer()
                     .json()
-                    .with_span_events(FmtSpan::FULL)
+                    .flatten_event(true)
+                    .with_thread_ids(true)
+                    .with_span_list(false)
+                    .with_span_events(FmtSpan::ACTIVE)
                     .with_writer(sink),
             );
 


### PR DESCRIPTION
# Overview

Broker generates a lot of traces. This can result in very large trace file sizes. This PR aims to reduce file size by updating the trace subscriber layer to:
* Reducing trace verbosity
* Only logging span `new` and `close` events

## Does this even work?

I ran broker against a handful of repos independently. Here are the results:
| Repo | Old trace file size | New trace file size | Diff |
|--------|--------|--------|--------|
| https://github.com/fossas/fossa-cli | 11.6MB | 1.6MB | -10MB (-86%)
| https://github.com/tensorflow/tensorflow | 168.7MB | 2.4MB |  -166.3MB (-99%)
| https://github.com/kubernetes/kubernetes | 403.1MB | 2.5MB | -400.6MB (-99%)
|https://github.com/facebook/react | 2.04GB | 62.3MB | -1.98GB (-97%)

As you can see: a significant improvement.

## What else can we do?

The ticket points to two possible improvements that I think would be more consistent/substantial than the changes are able to accomplish here. 

The first is to compress the trace files:
> We should also probably store the trace files compressed. Since compression algorithms rely on a dictionary of compression words, this would normally mean keeping the trace file open as a compression stream through the whole program lifetime, however we want to be as resilient as possible to program termination (modulo disk cache, can’t do much about that). So we’ll probably need to have a system where the primary trace file is written uncompressed, and a background job periodically compresses it into a larger trace file that spans the entire day.

The second is to serialize the traces in something more compact than json:
> Lastly, it may be useful to record traces in a format other than JSON. We chose this format in the hopes that it’d be debuggable without dedicated tooling (until we get tooling built up), but if switching to a different format would save a ton of space it’s probably worth taking the time to build the tooling. After all, it’s not really realistic for a person to review gigabytes of JSON, much less actually debug it, without dedicated tooling either.

I think both of these are strong options, but I fear they may be too time consuming for an inexperienced Rust developer like myself to do as part of this ticket. I am hoping that this improvement is satisfactory enough, but perhaps we should make follow-up tickets for either of these two options.

## Note about unit tests

There doesn't seem to be a precedent for testing the traces, so I haven't added any. Let me know if there's a good way to add some.

## Acceptance criteria

* Broker trace file size should now be smaller

## Testing plan

1. Run broker for a period of time **without** these changes and observe the `broker.trace` file size
2. Move the trace file somewhere else/wipe it completely.
3. Run broker for the same period of time **with** these changes and observe the `broker.trace` file size to be smaller

## Risks

We lose some trace information, such as when spans are entered/exited. We still have info on when spans are created and closed though, which I think is more relevant.

## References

- [ANE-1027](https://fossa.atlassian.net/browse/ANE-1027): Make Broker trace file size more manageable

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).


[ANE-1027]: https://fossa.atlassian.net/browse/ANE-1027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ