### PR TITLE
[ANE-2329] Support env filter for tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.3.3
+Features:
+- Support RUST_LOG environment variable for trace filtering
+
 ## v0.3.2
 
 Features:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ thiserror = "1.0.40"
 tokio = { version = "1.32.0", features = ["full", "fs"] }
 tracing = "0.1.37"
 tracing-appender = "0.2.2"
-tracing-subscriber = { version = "0.3.17", features = ["json"] }
+tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }
 url = "2.4.0"
 base64 = "0.21.2"
 itertools = "0.10.5"

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -16,7 +16,7 @@ use rolling_file::{BasicRollingFileAppender, RollingConditionBasic};
 use tracing::{info, Metadata};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{
-    filter, fmt::format::FmtSpan, layer::Context, prelude::*, Layer, Registry,
+    filter, fmt::format::FmtSpan, layer::Context, prelude::*, EnvFilter, Layer, Registry,
 };
 
 use crate::ext::{
@@ -143,7 +143,9 @@ impl Config {
                     .flatten_event(true)
                     .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
                     .with_writer(sink),
-            );
+            )
+            // filter traces based on RUST_LOG environment filter
+            .with(EnvFilter::from_default_env());
 
         tracing::subscriber::set_global_default(subscriber)
             .context(Error::TraceSinkReconfigured)

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -13,7 +13,7 @@ use derive_new::new;
 use error_stack::{report, Report, ResultExt};
 use getset::{CopyGetters, Getters};
 use rolling_file::{BasicRollingFileAppender, RollingConditionBasic};
-use tracing::{info, Metadata};
+use tracing::{info, level_filters::LevelFilter, Metadata};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{
     filter, fmt::format::FmtSpan, layer::Context, prelude::*, EnvFilter, Layer, Registry,
@@ -144,8 +144,13 @@ impl Config {
                     .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
                     .with_writer(sink),
             )
-            // filter traces based on RUST_LOG environment filter
-            .with(EnvFilter::from_default_env());
+            // filter traces based on RUST_LOG environment variable
+            // see: https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/filter/struct.EnvFilter.html#directives
+            .with(
+                EnvFilter::builder()
+                    .with_default_directive(LevelFilter::TRACE.into())
+                    .from_env_lossy(),
+            );
 
         tracing::subscriber::set_global_default(subscriber)
             .context(Error::TraceSinkReconfigured)


### PR DESCRIPTION
# Overview

While the changes in #146 reduced trace file size significantly, some users still report excessive tracing. To combat this, we can allow users to run broker with the `RUST_LOG` environment variable, allowing them apply a custom filter to the traces that are logged.

## Acceptance criteria

* Broker filters trace output according to `RUST_LOG` env var
* If `RUST_LOG` is not passed, traces are outputted as they normally would be

## Testing plan

I ran broker four roughly 2 minutes while it was configured to poll 4 repos.
| RUST_LOG | trace file size |
|--------|--------|
| (unset) | 82.7 MB |
| `none,broker=trace` | 74.1 MB |
| `none,broker=debug` | 281 KB | 

## Risks

The filter defaults to the same tracing level as we currently do without the filter, so I don't see any risk with this.

## References

- [ANE_2329](https://fossa.atlassian.net/browse/ANE-2329) Broker trace file ballooning in size

## Checklist

- [ ] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
