### PR TITLE
Use macos-latest

### DIFF
--- a/.github/workflows/dynamic-analysis.yml
+++ b/.github/workflows/dynamic-analysis.yml
@@ -10,7 +10,7 @@ jobs:
         include:
         - os: ubuntu-latest
           toolchain: stable
-        - os: macos-13
+        - os: macos-latest
           toolchain: stable
         - os: windows-latest
           toolchain: stable
@@ -53,7 +53,7 @@ jobs:
         include:
         - os: ubuntu-latest
           toolchain: stable
-        - os: macos-13
+        - os: macos-latest
           toolchain: stable
         - os: windows-latest
           toolchain: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,12 +41,12 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ['windows-latest', 'ubuntu-latest', 'macos-13']
+        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
         include:
           - os: ubuntu-latest
             os-name: linux
             toolchain: stable
-          - os: macos-13
+          - os: macos-latest
             os-name: macos
             toolchain: stable
           - os: windows-latest


### PR DESCRIPTION
Follow-up of #149 to address this comment https://github.com/fossas/broker/pull/149#discussion_r2012715014.

Gist: we may as well use `macos-latest` so we don't have to update the next time a macos image gets deprecated.