### PR TITLE
Revert concurrency limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 
+## v0.3.6
+
+Temporarily reverts concurrency limiting.
+
+We plan to bring this back so the config value is still supported, but it is currently ignored.
+
+Broker emits a `warn` message at startup accordingly:
+```sh
+2025-05-21T21:15:52.478157Z the concurrency setting is temporarily ignored, but we plan to support it again in a future release. concurrency=2
+```
+
 ## v0.3.5
 
 Fixes:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aho-corasick 0.7.20",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "broker"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 description = "The bridge between FOSSA and internal DevOps services"
 readme = "README.md"

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -124,7 +124,7 @@ struct CmdContext<D> {
 pub async fn main<D: Database>(ctx: &AppContext, config: Config, db: D) -> Result<(), Error> {
     warn!(
         concurrency = config.concurrency(),
-        "the concurrency setting is temporarily ignored, but we plan to support it again in a future release."
+        "The concurrency setting is temporarily ignored, but we plan to support it again in a future release"
     );
 
     let cli = fossa_cli::find_or_download(ctx, config.debug().location(), DesiredVersion::Latest)

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -10,7 +10,6 @@ use indoc::indoc;
 use nonzero_ext::nonzero;
 use serde::{Deserialize, Serialize};
 use tap::TapFallible;
-use tokio::sync::{Semaphore, SemaphorePermit};
 use tokio_retry::strategy::jitter;
 use tokio_retry::strategy::ExponentialBackoff;
 use tokio_retry::Retry;
@@ -23,7 +22,6 @@ use crate::api::remote::git::repository;
 use crate::api::remote::{
     git, BranchImportStrategy, Integrations, Protocol, Reference, TagImportStrategy,
 };
-use crate::ext::error_stack::IntoContext;
 use crate::ext::result::WrapErr;
 use crate::ext::tracing::span_record;
 use crate::fossa_cli::{self, DesiredVersion, Location, SourceUnits};
@@ -45,10 +43,6 @@ pub enum Error {
     /// Application health check failed.
     #[error("health check failed")]
     Healthcheck,
-
-    /// Acquiring a concurrency permit failed.
-    #[error("acquiring concurrency permit failed")]
-    AcquireConcurrencyPermit,
 
     /// Setting up async pipeline failed.
     #[error("set up task pipeline")]
@@ -121,38 +115,26 @@ struct CmdContext<D> {
     /// The database connection.
     db: D,
 
-    /// The semaphore for global concurrency of integrations.
-    concurrency: Semaphore,
-
     /// The location of FOSSA CLI
     cli: Location,
-}
-
-impl<D> CmdContext<D> {
-    /// Acquire a concurrency permit from the global limiter.
-    pub async fn acquire_permit(&self) -> Result<SemaphorePermit<'_>, Error> {
-        self.concurrency
-            .acquire()
-            .await
-            .context(Error::AcquireConcurrencyPermit)
-            .describe("Broker limits concurrent integration operations to the value specified in the config file.")
-            .help("this is almost definitely a temporary condition or a bug, restarting Broker may resolve the issue")
-    }
 }
 
 /// The primary entrypoint.
 #[tracing::instrument(skip_all, fields(subcommand = "run"))]
 pub async fn main<D: Database>(ctx: &AppContext, config: Config, db: D) -> Result<(), Error> {
+    warn!(
+        concurrency = config.concurrency(),
+        "the concurrency setting is temporarily ignored, but we plan to support it again in a future release."
+    );
+
     let cli = fossa_cli::find_or_download(ctx, config.debug().location(), DesiredVersion::Latest)
         .await
         .change_context(Error::DownloadFossaCli)
         .describe("Broker relies on fossa-cli to perform analysis of your projects")?;
     info!(?cli, "using fossa cli");
 
-    let concurrency = config.semaphore();
     let ctx = CmdContext {
         app: ctx.clone(),
-        concurrency,
         config,
         db,
         cli,
@@ -362,8 +344,6 @@ async fn execute_poll_integration<D: Database>(
     integration: &Integration,
     sender: &Queue<ScanGitVCSReference>,
 ) -> Result<(), Error> {
-    let _permit = ctx.acquire_permit().await?;
-
     // We use this in a few places and may send it across threads, so just clone it locally.
     let remote = integration.remote().to_owned();
 
@@ -484,7 +464,6 @@ async fn execute_scan_git_references<D: Database>(
     receiver: &Queue<ScanGitVCSReference>,
     uploader: &Queue<UploadSourceUnits>,
 ) -> Result<(), Error> {
-    let _permit = ctx.acquire_permit().await?;
     let job = receiver.recv().await.change_context(Error::TaskReceive)?;
     let upload = scan_git_reference(ctx, &job)
         .await


### PR DESCRIPTION
# Overview

In some environments, we found that concurrency limiting prevents Broker from working properly.

We've been unable to reproduce locally, but user logs are clear about what's happening.
We believe the root cause is due to how we perform concurrency mixed with some environments, so we plan to refactor this.

However, in the mean time this PR reverts concurrency limiting.

## Acceptance criteria

- Broker no longer has a concurrency limit
- Broker logs a warning about this

## Testing plan

Ran locally and it seems this is indeed ignored.

```sh
; cargo run -- run
   Compiling broker v0.3.6 (/Users/jess/projects/broker)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.58s
     Running `target/debug/broker run`
2025-05-21T21:15:52.466676Z Debug artifacts being stored in '/Users/jess/.config/fossa/broker/debugging/trace'
2025-05-21T21:15:52.478157Z the concurrency setting is temporarily ignored, but we plan to support it again in a future release. concurrency=2
2025-05-21T21:15:53.257392Z using fossa cli cli=Location { cli: "/Users/jess/.config/fossa/broker/fossa", artifacts: Root("/Users/jess/.config/fossa/broker/debugging/") }
2025-05-21T21:15:53.260849Z Polling 'git::http::https://github.com/fossas/broker.git'
2025-05-21T21:15:53.462185Z Polling 'git::http::https://github.com/fossas/locator-rs.git'
2025-05-21T21:15:53.463462Z Polling 'git::http::https://github.com/fossas/circe.git'
2025-05-21T21:15:53.625863Z No changes to 'git::http::https://github.com/fossas/broker.git'
2025-05-21T21:15:53.625953Z Next poll interval for 'git::http::https://github.com/fossas/broker.git' in 3600s
2025-05-21T21:15:53.800895Z No changes to 'git::http::https://github.com/fossas/locator-rs.git'
2025-05-21T21:15:53.801176Z Next poll interval for 'git::http::https://github.com/fossas/locator-rs.git' in 3600s
2025-05-21T21:15:53.896717Z No changes to 'git::http::https://github.com/fossas/circe.git'
2025-05-21T21:15:53.897115Z Next poll interval for 'git::http::https://github.com/fossas/circe.git' in 3600s
```

## Risks

This brings back the possibility for a huge number of integrations to cause more load (both locally and on remote servers) but probably preferable to totally not working as we're seeing.

## References

https://teamfossa.slack.com/archives/C039KE5ERNE/p1747251479521369

## Checklist

- [x] I added tests for this PR's change (or explained in the PR description why tests don't make sense).
